### PR TITLE
feat: add DNS record for hana admin panel behind IAP

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -138,3 +138,15 @@ resource "cloudflare_dns_record" "root_txt_atproto" {
   ttl     = 86400
   content = "did=did:plc:fzeed6j234rni24nk2gr6u53"
 }
+
+# hana admin panel, behind IAP on a Google Cloud external HTTPS load balancer.
+# Must stay DNS-only (not proxied): the LB IP needs a Google-managed SSL cert
+# and IAP's own auth, so Cloudflare's proxy would break both.
+resource "cloudflare_dns_record" "hana_admin_a" {
+  zone_id = cloudflare_zone.toof_jp.id
+  name    = "hana-admin.toof.jp"
+  type    = "A"
+  ttl     = 60
+  content = "136.68.11.50"
+  proxied = false
+}


### PR DESCRIPTION
## Summary
- Adds an A record for `hana-admin.toof.jp` pointing at `136.68.11.50`, the static IP of the external HTTPS load balancer created in the `hana` project (`hana-point-dev`) to front its IAP-protected admin Cloud Run service.
- Record is DNS-only (`proxied = false`): Cloudflare's proxy would break Google's managed SSL certificate validation and IAP's own TLS/auth handling.

## Test plan
- [ ] `terraform plan` shows only the new `cloudflare_dns_record.hana_admin_a` resource being added
- [ ] After apply, `dig hana-admin.toof.jp` resolves to `136.68.11.50`
- [ ] Google-managed SSL cert for `hana-admin.toof.jp` (in the `hana-point-dev` project) transitions to ACTIVE once DNS propagates
- [ ] `https://hana-admin.toof.jp` prompts the IAP Google sign-in flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)