### PR TITLE
feat: add DNS record for hana user site behind IAP

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -150,3 +150,13 @@ resource "cloudflare_dns_record" "hana_admin_a" {
   content = "136.68.11.50"
   proxied = false
 }
+
+# hana user-facing site, same IAP-on-Google-LB setup as hana-admin above.
+resource "cloudflare_dns_record" "hana_user_a" {
+  zone_id = cloudflare_zone.toof_jp.id
+  name    = "hana.toof.jp"
+  type    = "A"
+  ttl     = 60
+  content = "8.233.52.20"
+  proxied = false
+}


### PR DESCRIPTION
## Summary
- Adds an A record for `hana.toof.jp` pointing at `8.233.52.20`, the static IP of the external HTTPS load balancer fronting the hana project's IAP-protected **user** Cloud Run service (`hana-point-dev`), mirroring the `hana-admin.toof.jp` setup from #82.
- DNS-only (`proxied = false`) for the same reason as before: Google-managed SSL cert validation and IAP need direct traffic.

## Test plan
- [ ] Speculative plan shows only the new `cloudflare_dns_record.hana_user_a` being added
- [ ] After apply, `dig hana.toof.jp` resolves to `8.233.52.20`
- [ ] `hana-dev-user-cert` transitions to ACTIVE, then `https://hana.toof.jp` prompts IAP Google sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)