### PR TITLE
fix: let Longhorn use sakura-vps as a storage node

### DIFF
--- a/kubernetes/applications/longhorn.yaml
+++ b/kubernetes/applications/longhorn.yaml
@@ -17,6 +17,20 @@ spec:
         valuesObject:
           preUpgradeChecker:
             jobEnabled: false
+          defaultSettings:
+            taintToleration: node-role.kubernetes.io/control-plane=:NoSchedule
+            defaultReplicaCount: 2
+          persistence:
+            defaultClassReplicaCount: 2
+          longhornManager:
+            tolerations: &controlPlaneToleration
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+                effect: NoSchedule
+          longhornDriver:
+            tolerations: *controlPlaneToleration
+          longhornUI:
+            tolerations: *controlPlaneToleration
           ingress:
             enabled: true
             host: longhorn.toof.jp


### PR DESCRIPTION
## 問題

- Longhorn のノードが zen2 のみで、デフォルト replica 数 3 に対しノードが 1 台しかなく、ボリュームが常に degraded / スケジュール不能だった
- sakura-vps は設計上 control-plane taint (`node-role.kubernetes.io/control-plane:NoSchedule`) を保持しているため（nix-sandbox/sakura-vps/README.md 参照）、Longhorn の DaemonSet が一切スケジュールされず、ストレージノードとして使えていなかった

## 変更

- Longhorn の全コンポーネントに control-plane taint の toleration を追加
  - chart 管理の pod (manager / driver / UI) は各コンポーネントの `tolerations`
  - システム管理 pod (instance-manager / CSI / engine image) は `defaultSettings.taintToleration`
- デフォルト replica 数を 2 ノード構成に合わせて 3 → 2 に変更（StorageClass の `numberOfReplicas` と `default-replica-count` 設定の両方）

これにより sakura-vps が Longhorn のストレージノードになり、ボリュームデータが zen2 と さくらの VPS の両方に複製される。

## デプロイ前提（NixOS 側）

sakura-vps に open-iscsi (iscsid) と `/usr/local/bin` → `/run/current-system/sw/bin` のシンボリックリンクが必要。nix-sandbox リポジトリの `sakura-vps/configuration.nix` に変更を用意済み（別途デプロイ要）。

## マージ後の手順

1. nix-sandbox 側の変更を sakura-vps にデプロイ（`nixos-rebuild switch`）
2. ArgoCD で longhorn Application を手動 Sync（auto-sync 未設定のため）
3. `kubectl get nodes.longhorn.io -n longhorn-system` に sakura-vps が Ready で現れることを確認

## 注意

- `taint-toleration` 設定の反映には全ボリュームの detach が必要だが、現在唯一のボリューム (pvc-59b843c1, テスト用) は detached 状態なので問題なし
- sakura-vps はメモリ 2GB と少ないため、Longhorn (manager + instance-manager + CSI) の常駐でメモリはかなりタイトになる見込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)