### PR TITLE
fix: store Longhorn volume data only on sakura-vps

### DIFF
--- a/kubernetes/applications/longhorn.yaml
+++ b/kubernetes/applications/longhorn.yaml
@@ -19,9 +19,9 @@ spec:
             jobEnabled: false
           defaultSettings:
             taintToleration: node-role.kubernetes.io/control-plane=:NoSchedule
-            defaultReplicaCount: 2
+            defaultReplicaCount: 1
           persistence:
-            defaultClassReplicaCount: 2
+            defaultClassReplicaCount: 1
           longhornManager:
             tolerations: &controlPlaneToleration
               - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
zen2 はストレージノードとして使わない方針のため、デフォルト replica 数を 2 → 1 に変更（データは sakura-vps のみに保存）。

マージ後、zen2 の Longhorn ディスクのスケジューリングを無効化する（`nodes.longhorn.io/zen2` の `allowScheduling: false`、こちらは Longhorn の実行時設定なので kubectl で対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)