### PR TITLE
feat(terraform): provision vultr-vps k8s node

### DIFF
--- a/terraform/hcp_terraform.tf
+++ b/terraform/hcp_terraform.tf
@@ -78,6 +78,26 @@ locals {
       value     = var.tfe_oauth_token_id
       sensitive = true
     }
+    auth0_domain = {
+      value     = var.auth0_domain
+      sensitive = false
+    }
+    auth0_client_id = {
+      value     = var.auth0_client_id
+      sensitive = false
+    }
+    auth0_client_secret = {
+      value     = var.auth0_client_secret
+      sensitive = true
+    }
+    domain = {
+      value     = var.domain
+      sensitive = false
+    }
+    vultr_api_key = {
+      value     = var.vultr_api_key
+      sensitive = true
+    }
     AWS_ACCESS_KEY_ID = {
       value     = local.aws_access_key_id_value
       sensitive = true

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -25,6 +25,16 @@ terraform {
       version = "0.78.0"
     }
 
+    auth0 = {
+      source  = "auth0/auth0"
+      version = "~> 1"
+    }
+
+    vultr = {
+      source  = "vultr/vultr"
+      version = "~> 2"
+    }
+
     terraform = {
       source = "terraform.io/builtin/terraform"
     }
@@ -61,4 +71,14 @@ provider "discord" {
 
 provider "tfe" {
   token = var.tfe_token
+}
+
+provider "auth0" {
+  domain        = var.auth0_domain
+  client_id     = var.auth0_client_id
+  client_secret = var.auth0_client_secret
+}
+
+provider "vultr" {
+  api_key = var.vultr_api_key
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,3 +39,54 @@ variable "tfe_oauth_token_id" {
   type      = string
   sensitive = true
 }
+
+variable "auth0_domain" {
+  type        = string
+  description = "Auth0 tenant domain, e.g. xxx.auth0.com."
+}
+
+variable "auth0_client_id" {
+  type        = string
+  description = "Auth0 Management API client ID for Terraform."
+}
+
+variable "auth0_client_secret" {
+  type        = string
+  sensitive   = true
+  description = "Auth0 Management API client secret for Terraform."
+}
+
+variable "domain" {
+  type        = string
+  description = "Base public domain."
+  default     = "toof.jp"
+}
+
+variable "vultr_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "vultr_region" {
+  type        = string
+  description = "Vultr region for the k8s node (nrt = Tokyo, itm = Osaka)."
+  default     = "nrt"
+}
+
+variable "vultr_plan" {
+  type        = string
+  description = "Vultr plan ID. vhp-1c-2gb-amd = High Performance AMD 1vCPU/2GB."
+  default     = "vhp-1c-2gb-amd"
+}
+
+variable "vultr_iso_url" {
+  type        = string
+  description = "Public URL of the NixOS installer ISO (built with `make vultr-iso` in toof-jp/nix-sandbox). Vultr downloads it into My ISOs."
+  default     = ""
+}
+
+variable "vultr_attach_iso" {
+  type        = bool
+  description = "Boot the instance from the installer ISO. Set to false after `vultr-install` so the node boots NixOS from disk."
+  default     = true
+}

--- a/terraform/vultr.tf
+++ b/terraform/vultr.tf
@@ -1,0 +1,108 @@
+# vultr-vps: k8s node joining the zen2/sakura-vps cluster over Tailscale.
+#
+# The instance boots the custom NixOS installer ISO built from
+# toof-jp/nix-sandbox (`make vultr-iso`), hosted at var.vultr_iso_url so
+# Vultr can fetch it. Install flow:
+#   1. make vultr-iso, upload result somewhere Vultr can reach, set
+#      vultr_iso_url
+#   2. apply — instance boots the installer; ssh root@<ip>, run
+#      `vultr-install`
+#   3. set vultr_attach_iso = false, apply — detaches the ISO so the
+#      instance boots NixOS from disk
+
+resource "vultr_iso_private" "nixos_installer" {
+  count = var.vultr_iso_url == "" ? 0 : 1
+  url   = var.vultr_iso_url
+}
+
+resource "vultr_ssh_key" "toof" {
+  name    = "toof@toof.jp"
+  ssh_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIN8H2c3Qa2EsEh6RQG6nRoRFblH8fj5dHj9YyVD9tND toof@toof.jp"
+}
+
+# Cluster traffic (apiserver, etcd, kubelet) flows over the Tailscale mesh,
+# so only SSH and Tailscale's WireGuard port are exposed publicly — same
+# policy as sakura-vps's NixOS firewall.
+resource "vultr_firewall_group" "k8s_node" {
+  description = "k8s node: ssh + tailscale only"
+}
+
+resource "vultr_firewall_rule" "ssh_v4" {
+  firewall_group_id = vultr_firewall_group.k8s_node.id
+  protocol          = "tcp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+  port              = "22"
+}
+
+resource "vultr_firewall_rule" "ssh_v6" {
+  firewall_group_id = vultr_firewall_group.k8s_node.id
+  protocol          = "tcp"
+  ip_type           = "v6"
+  subnet            = "::"
+  subnet_size       = 0
+  port              = "22"
+}
+
+resource "vultr_firewall_rule" "tailscale_v4" {
+  firewall_group_id = vultr_firewall_group.k8s_node.id
+  protocol          = "udp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+  port              = "41641"
+}
+
+resource "vultr_firewall_rule" "tailscale_v6" {
+  firewall_group_id = vultr_firewall_group.k8s_node.id
+  protocol          = "udp"
+  ip_type           = "v6"
+  subnet            = "::"
+  subnet_size       = 0
+  port              = "41641"
+}
+
+resource "vultr_firewall_rule" "icmp_v4" {
+  firewall_group_id = vultr_firewall_group.k8s_node.id
+  protocol          = "icmp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+}
+
+resource "vultr_instance" "vultr_vps" {
+  label    = "vultr-vps"
+  hostname = "vultr-vps"
+  region   = var.vultr_region
+  plan     = var.vultr_plan
+
+  iso_id = var.vultr_attach_iso ? vultr_iso_private.nixos_installer[0].id : null
+
+  ssh_key_ids       = [vultr_ssh_key.toof.id]
+  firewall_group_id = vultr_firewall_group.k8s_node.id
+
+  enable_ipv6      = true
+  backups          = "disabled"
+  ddos_protection  = false
+  activation_email = false
+
+  lifecycle {
+    # The disk is managed by nixos-install, not Vultr images; never let a
+    # drifted/computed os_id trigger a reinstall of a converted node.
+    ignore_changes = [os_id]
+
+    precondition {
+      condition     = !var.vultr_attach_iso || var.vultr_iso_url != ""
+      error_message = "vultr_attach_iso is true but vultr_iso_url is empty — build the ISO (make vultr-iso in nix-sandbox), host it, and set vultr_iso_url."
+    }
+  }
+}
+
+output "vultr_vps_ipv4" {
+  value = vultr_instance.vultr_vps.main_ip
+}
+
+output "vultr_vps_ipv6" {
+  value = vultr_instance.vultr_vps.v6_main_ip
+}


### PR DESCRIPTION
Vultr instance (High Performance AMD 2GB, Tokyo) that boots the custom NixOS installer ISO from toof-jp/nix-sandbox via vultr_iso_private. Public exposure is SSH + Tailscale's WireGuard port only; cluster traffic stays on the tailscale mesh. After running `vultr-install` on the box, flip vultr_attach_iso to false to detach the ISO and boot from disk.