### PR TITLE
feat(terraform): detach the installer ISO from vultr-vps

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,5 +72,5 @@ variable "vultr_iso_url" {
 variable "vultr_attach_iso" {
   type        = bool
   description = "Boot the instance from the installer ISO. Set to false after `vultr-install` so the node boots NixOS from disk."
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
Flip `vultr_attach_iso` default to `false` so vultr-vps boots NixOS from disk.

⚠️ **Merge only after `vultr-install` has finished on the box** — detaching the ISO restarts the instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)