### PR TITLE
fix(terraform): keep vultr_api_key hcl=false, drop finished import block

### DIFF
--- a/terraform/hcp_terraform.tf
+++ b/terraform/hcp_terraform.tf
@@ -85,6 +85,9 @@ locals {
     vultr_api_key = {
       value     = var.vultr_api_key
       sensitive = true
+      # Hand-seeded in the workspace with hcl=false; TFE refuses to flip
+      # the hcl flag on a sensitive variable, so keep managing it as-is.
+      hcl = false
     }
     AWS_ACCESS_KEY_ID = {
       value     = local.aws_access_key_id_value
@@ -122,8 +125,8 @@ resource "tfe_variable" "infra_variables" {
 
   key          = each.key
   category     = lookup(each.value, "category", "terraform")
-  value        = lookup(each.value, "category", "terraform") == "terraform" ? provider::terraform::encode_expr(each.value.value) : tostring(each.value.value)
+  value        = lookup(each.value, "hcl", lookup(each.value, "category", "terraform") == "terraform") ? provider::terraform::encode_expr(each.value.value) : tostring(each.value.value)
   workspace_id = tfe_workspace.infra.id
-  hcl          = lookup(each.value, "category", "terraform") == "terraform"
+  hcl          = lookup(each.value, "hcl", lookup(each.value, "category", "terraform") == "terraform")
   sensitive    = each.value.sensitive
 }

--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -1,9 +1,0 @@
-# The vultr_api_key workspace variable was seeded by hand (bootstrap) before
-# tfe_variable.infra_variables could manage it, so the first run after PR #93
-# failed with "Key has already been taken". Adopt the existing variable into
-# state instead of recreating it. This block is a no-op once imported and can
-# be removed afterwards.
-import {
-  to = tfe_variable.infra_variables["vultr_api_key"]
-  id = "toof-infra/toof-infra/var-ygj974GHfRFxUyzU"
-}


### PR DESCRIPTION
The run after #95 imported the hand-seeded `vultr_api_key` variable successfully, but then failed updating it: the TFE API rejects flipping `hcl` on a sensitive variable ("Hcl cannot be updated for a sensitive variable"), and the variable map forces `hcl=true` for all terraform-category entries.

- Add an optional per-entry `hcl` override to `hcp_terraform_variables` (defaults to the existing category-based rule)
- Set `hcl = false` for `vultr_api_key`, matching how it exists in the workspace
- Remove `imports.tf` — the import in #95 already landed in state

🤖 Generated with [Claude Code](https://claude.com/claude-code)