### PR TITLE
feat: add metrics-server and kube-prometheus-stack monitoring

### DIFF
--- a/kubernetes/applications/kube-prometheus-stack.yaml
+++ b/kubernetes/applications/kube-prometheus-stack.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://prometheus-community.github.io/helm-charts
+    chart: kube-prometheus-stack
+    targetRevision: 87.10.1
+    helm:
+      valuesObject:
+        # No receivers configured yet — enable once alert routing (e.g.
+        # Discord) is decided.
+        alertmanager:
+          enabled: false
+        # kubeadm binds scheduler/controller-manager/etcd metrics to
+        # localhost (etcd: 127.0.0.1:2381), so these targets are
+        # unscrapable without changing the static-pod manifests. Disabled
+        # to avoid permanently-firing "target down" noise.
+        kubeControllerManager:
+          enabled: false
+        kubeScheduler:
+          enabled: false
+        kubeProxy:
+          enabled: false
+        kubeEtcd:
+          enabled: false
+        # The VPS nodes are small and already busy being control planes;
+        # keep the heavy components on zen2. node-exporter still runs on
+        # every node (it must, to report per-node CPU), tolerating the
+        # control-plane taint on the VPSes.
+        prometheusOperator:
+          nodeSelector: &zen2
+            kubernetes.io/hostname: zen2
+        prometheus:
+          prometheusSpec:
+            nodeSelector: *zen2
+            retention: 15d
+            storageSpec:
+              volumeClaimTemplate:
+                spec:
+                  storageClassName: longhorn
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: 20Gi
+        kube-state-metrics:
+          nodeSelector: *zen2
+        prometheus-node-exporter:
+          tolerations:
+            - operator: Exists
+        grafana:
+          nodeSelector: *zen2
+          # AuthN happens at the edge: grafana.toof.jp sits behind a
+          # Cloudflare Access application (terraform/access.tf). Grafana's
+          # own login (admin / prom-operator by default) is the second
+          # layer — change it after first login.
+          ingress:
+            enabled: true
+            ingressClassName: cloudflare-tunnel
+            hosts:
+              - grafana.toof.jp
+          grafana.ini:
+            server:
+              root_url: https://grafana.toof.jp
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      # The stack's CRDs blow past the client-side-apply annotation limit.
+      - ServerSideApply=true

--- a/kubernetes/applications/metrics-server.yaml
+++ b/kubernetes/applications/metrics-server.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes-sigs.github.io/metrics-server/
+    chart: metrics-server
+    targetRevision: 3.13.1
+    helm:
+      valuesObject:
+        args:
+          # kubeadm kubelets serve self-signed certs; without this the
+          # metrics-server can't scrape any node.
+          - --kubelet-insecure-tls
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/terraform/access.tf
+++ b/terraform/access.tf
@@ -118,3 +118,22 @@ resource "cloudflare_zero_trust_access_application" "longhorn" {
     }
   ]
 }
+
+resource "cloudflare_zero_trust_access_application" "grafana" {
+  account_id       = var.cloudflare_account_id
+  name             = "grafana"
+  domain           = "grafana.toof.jp"
+  type             = "self_hosted"
+  session_duration = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.github.id
+  ]
+
+  policies = [
+    {
+      id         = cloudflare_zero_trust_access_policy.allow_github_toof.id
+      precedence = 1
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- **metrics-server 3.13.1** — enables `kubectl top nodes` and k9s CPU/MEM columns (`--kubelet-insecure-tls` because kubeadm kubelets use self-signed certs)
- **kube-prometheus-stack 87.10.1** — Prometheus (15d retention, 20Gi longhorn PVC) + Grafana + node-exporter + kube-state-metrics
  - Prometheus/Grafana/operator/KSM pinned to zen2 with nodeSelector — keeps load off the small VPS control planes (today's etcd lesson)
  - node-exporter runs on all 3 nodes (tolerates the control-plane taint) so per-node CPU is visible cluster-wide
  - Alertmanager disabled until alert routing is decided; localhost-bound kubeadm component scrapes (etcd/scheduler/controller-manager/kube-proxy) disabled to avoid permanent "target down" noise
- **Cloudflare Access**: `grafana.toof.jp` behind the same GitHub IdP + `allow-github-toof` policy as warrior/argocd (terraform/access.tf)

## After merge
- ArgoCD app-of-apps picks up both Applications automatically
- Grafana: https://grafana.toof.jp (Cloudflare Access → then Grafana login `admin` / `prom-operator`; change it on first login)
- `kubectl top nodes` / k9s `:nodes` work once metrics-server is Ready (~1 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)