### PR TITLE
chore(bbs): scale postgres to 0 for longhorn migration (step 1/2)

### DIFF
--- a/kubernetes/applications/bbs/db.yaml
+++ b/kubernetes/applications/bbs/db.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: bbs
 spec:
   serviceName: postgres
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: postgres


### PR DESCRIPTION
Stops postgres so its data files can be copied cold from the zen2 hostPath (`/var/lib/kubernetes/bbs-postgres`, 1.7GB) into a longhorn volume. **bbs is down from this merge until step 2 completes** (expect ~10–15 min total).

Step 2 PR (volume switch to longhorn + hostPath PV removal) follows once the copy is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)