### PR TITLE
feat: move shisha-log DB to self-hosted Postgres on k8s

### DIFF
--- a/kubernetes/applications/shisha-log/db.yaml
+++ b/kubernetes/applications/shisha-log/db.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: shisha-log
+  labels:
+    app: postgres
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: shisha-log
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:18
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: shisha_log
+            - name: POSTGRES_DB
+              value: shisha_log
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-external-secret
+  namespace: shisha-log
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: postgres-secret
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: shisha-log-db-password

--- a/kubernetes/applications/shisha-log/migration.yaml
+++ b/kubernetes/applications/shisha-log/migration.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shisha-log-schema
+  namespace: shisha-log
+data:
+  schema.sql: |
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+        CREATE ROLE service_role NOLOGIN;
+      END IF;
+    END
+    $$;
+
+    GRANT service_role TO shisha_log;
+
+    CREATE TABLE IF NOT EXISTS public.users (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id TEXT UNIQUE NOT NULL,
+        password_hash TEXT NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS public.password_reset_tokens (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+        token TEXT UNIQUE NOT NULL,
+        expires_at TIMESTAMPTZ NOT NULL,
+        used BOOLEAN DEFAULT FALSE,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS public.shisha_sessions (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+        created_by UUID NOT NULL REFERENCES public.users(id),
+        session_date TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        store_name TEXT,
+        notes TEXT,
+        order_details TEXT,
+        mix_name TEXT,
+        creator TEXT,
+        amount INTEGER DEFAULT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS public.session_flavors (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        session_id UUID NOT NULL REFERENCES public.shisha_sessions(id) ON DELETE CASCADE,
+        flavor_name TEXT,
+        brand TEXT,
+        flavor_order INTEGER NOT NULL DEFAULT 1,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS public.refresh_tokens (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+        token TEXT NOT NULL UNIQUE,
+        expires_at TIMESTAMPTZ NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+        used_at TIMESTAMPTZ,
+        revoked_at TIMESTAMPTZ
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_users_user_id ON public.users(user_id);
+    CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON public.shisha_sessions(user_id);
+    CREATE INDEX IF NOT EXISTS idx_sessions_date ON public.shisha_sessions(session_date DESC);
+    CREATE INDEX IF NOT EXISTS idx_flavors_session_id ON public.session_flavors(session_id);
+    CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_token ON public.password_reset_tokens(token);
+    CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON public.password_reset_tokens(user_id);
+    CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token ON public.refresh_tokens(token);
+    CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_id ON public.refresh_tokens(user_id);
+    CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires_at ON public.refresh_tokens(expires_at);
+
+    CREATE OR REPLACE FUNCTION public.handle_updated_at()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        NEW.updated_at = NOW();
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    DROP TRIGGER IF EXISTS handle_users_updated_at ON public.users;
+    CREATE TRIGGER handle_users_updated_at
+        BEFORE UPDATE ON public.users
+        FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+    DROP TRIGGER IF EXISTS handle_shisha_sessions_updated_at ON public.shisha_sessions;
+    CREATE TRIGGER handle_shisha_sessions_updated_at
+        BEFORE UPDATE ON public.shisha_sessions
+        FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+    CREATE OR REPLACE FUNCTION public.cleanup_expired_tokens()
+    RETURNS void AS $$
+    BEGIN
+        DELETE FROM public.password_reset_tokens
+        WHERE expires_at < NOW() OR used = TRUE;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    GRANT USAGE ON SCHEMA public TO service_role;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO service_role;
+    GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO service_role;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public
+        GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;
+
+    NOTIFY pgrst, 'reload schema';
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: shisha-log-migrate
+  namespace: shisha-log
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: postgres:18
+          command:
+            - psql
+          args:
+            - $(DATABASE_URL)
+            - -v
+            - ON_ERROR_STOP=1
+            - -f
+            - /sql/schema.sql
+          env:
+            - name: PGCONNECT_TIMEOUT
+              value: "10"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: postgrest-secret
+                  key: PGRST_DB_URI
+          volumeMounts:
+            - name: schema
+              mountPath: /sql
+      volumes:
+        - name: schema
+          configMap:
+            name: shisha-log-schema

--- a/kubernetes/applications/shisha-log/postgrest.yaml
+++ b/kubernetes/applications/shisha-log/postgrest.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgrest-nginx
+  namespace: shisha-log
+data:
+  nginx.conf: |
+    events {}
+    http {
+      server {
+        listen 8080;
+        location /rest/v1/ {
+          proxy_pass http://127.0.0.1:3000/;
+          proxy_set_header Host $host;
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgrest
+  namespace: shisha-log
+spec:
+  selector:
+    matchLabels:
+      app: postgrest
+  template:
+    metadata:
+      labels:
+        app: postgrest
+    spec:
+      containers:
+        - name: postgrest
+          image: postgrest/postgrest:v12.2.3
+          ports:
+            - name: postgrest
+              containerPort: 3000
+          env:
+            - name: PGRST_DB_SCHEMAS
+              value: public
+          envFrom:
+            - secretRef:
+                name: postgrest-secret
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: postgrest-nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgrest
+  namespace: shisha-log
+spec:
+  selector:
+    app: postgrest
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgrest-external-secret
+  namespace: shisha-log
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: postgrest-secret
+  data:
+    - secretKey: PGRST_DB_URI
+      remoteRef:
+        key: shisha-log-database-url
+    - secretKey: PGRST_JWT_SECRET
+      remoteRef:
+        key: shisha-log-pgrst-jwt-secret

--- a/kubernetes/applications/shisha-log/shisha-log.yaml
+++ b/kubernetes/applications/shisha-log/shisha-log.yaml
@@ -55,9 +55,6 @@ spec:
     - secretKey: SUPABASE_URL
       remoteRef:
         key: shisha-log-supabase-url
-    - secretKey: SUPABASE_ANON_KEY
-      remoteRef:
-        key: shisha-log-supabase-anon-key
     - secretKey: SUPABASE_SERVICE_ROLE_KEY
       remoteRef:
         key: shisha-log-supabase-service-role-key


### PR DESCRIPTION
## Summary
- Replace Supabase with a self-hosted Postgres 18 StatefulSet (Longhorn PVC) in the `shisha-log` namespace
- Add PostgREST + nginx sidecar: the backend's supabase-go client requests `{SUPABASE_URL}/rest/v1/...`, and nginx strips the `/rest/v1` prefix before proxying to PostgREST
- Add an idempotent schema migration Job (Argo CD Sync hook, `BeforeHookCreation`) that applies the unified schema (users, shisha_sessions with `amount`, session_flavors, password_reset_tokens, refresh_tokens) adapted from `toof-jp/shisha-log` migrations; RLS/auth.uid() parts are dropped since only the backend's `service_role` accesses the DB
- Drop the unused `SUPABASE_ANON_KEY` from the app's ExternalSecret

## Secrets (already done in GCP Secret Manager, project `toof-infra`)
- New: `shisha-log-db-password`, `shisha-log-pgrst-jwt-secret`
- New versions (old versions retained): `shisha-log-database-url`, `shisha-log-supabase-url` → in-cluster endpoints; `shisha-log-supabase-service-role-key` → HS256 JWT (`role=service_role`) signed with the PGRST secret

The migration Job reads `PGRST_DB_URI` from the new `postgrest-secret` (not the pre-existing `shisha-log-secret`) so it always gets the in-cluster DB URL.

## Post-merge steps
`shisha-log-secret` has `refreshPolicy: CreatedOnce`, so it still holds the old Supabase values:
```
kubectl delete secret shisha-log-secret -n shisha-log
kubectl rollout restart deployment/shisha-log -n shisha-log
```
Data starts fresh (confirmed OK; no data migration from Supabase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)