### PR TITLE
feat: serve kubernetes dashboard at k8s.toof.jp

### DIFF
--- a/kubernetes/applications/kubernetes-dashboard.yaml
+++ b/kubernetes/applications/kubernetes-dashboard.yaml
@@ -16,7 +16,7 @@ spec:
           ingress:
             enabled: true
             hosts:
-              - kubernetes-dashboard.toof.jp
+              - k8s.toof.jp
             ingressClassName: cloudflare-tunnel
             useDefaultIngressClass: false
             useDefaultAnnotations: false

--- a/terraform/access.tf
+++ b/terraform/access.tf
@@ -65,7 +65,7 @@ resource "cloudflare_zero_trust_access_application" "argocd" {
 resource "cloudflare_zero_trust_access_application" "kubernetes_dashboard" {
   account_id       = var.cloudflare_account_id
   name             = "kubernetes-dashboard"
-  domain           = "kubernetes-dashboard.toof.jp"
+  domain           = "k8s.toof.jp"
   type             = "self_hosted"
   session_duration = "24h"
 


### PR DESCRIPTION
Move the Kubernetes Dashboard from kubernetes-dashboard.toof.jp to k8s.toof.jp.

- Update the ingress host in the kubernetes-dashboard ArgoCD Application; the cloudflare-tunnel-ingress-controller picks up the new host and manages the tunnel DNS record automatically
- Point the existing Cloudflare Access application (GitHub IdP, allow-github-toof policy) at the new domain so authentication stays enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)