### PR TITLE
feat(bbs): move postgres onto the longhorn volume (step 2/2)

### DIFF
--- a/kubernetes/applications/bbs/db.yaml
+++ b/kubernetes/applications/bbs/db.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: bbs
 spec:
   serviceName: postgres
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: postgres
@@ -43,47 +43,10 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql
-  volumeClaimTemplates:
-    - metadata:
-        name: postgres-data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        storageClassName: manual
-        resources:
-          requests:
-            storage: 10Gi
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: manual
-provisioner: kubernetes.io/no-provisioner
-volumeBindingMode: Immediate
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: postgres-local-pv
-spec:
-  capacity:
-    storage: 10Gi
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: manual
-  hostPath:
-    path: /var/lib/kubernetes/bbs-postgres
-    type: DirectoryOrCreate
-  nodeAffinity:
-    required:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: kubernetes.io/hostname
-              operator: In
-              values:
-                - zen2
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-pvc
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
## What happened before this PR
- postgres scaled to 0 (#100), data copied cold from `/var/lib/kubernetes/bbs-postgres` (zen2 hostPath) into the re-provisioned `postgres-pvc` longhorn volume, contents verified (1.7GB, PG_VERSION present)
- Root cause of longhorn volumes never attaching on zen2 for 192 days: `iscsid` was not running on zen2 (now enabled via systemd)

## This PR
- StatefulSet mounts `postgres-pvc` (longhorn) directly; `volumeClaimTemplates` removed
- `manual` StorageClass and the zen2 hostPath PV removed
- replicas back to 1

## After merge (one manual step)
The volume switch is an immutable StatefulSet change, so ArgoCD's first sync errors. Run:
```
kubectl delete sts postgres -n bbs
```
ArgoCD then recreates the StatefulSet with the longhorn volume and postgres comes back with its data. Old hostPath data remains on zen2 as a fallback until we delete it manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)