### PR TITLE
feat: deploy bbs-mcp-server

### DIFF
--- a/kubernetes/applications/bbs/mcp-server.yaml
+++ b/kubernetes/applications/bbs/mcp-server.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-server
+  namespace: bbs
+spec:
+  selector:
+    matchLabels:
+      app: mcp-server
+  template:
+    metadata:
+      labels:
+        app: mcp-server
+    spec:
+      containers:
+        - name: mcp-server
+          image: ghcr.io/toof-jp/bbs-mcp-server:latest
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: BACKEND_BASE_URL
+              value: http://search-backend.bbs.svc.cluster.local:3000
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-server
+  namespace: bbs
+spec:
+  selector:
+    app: mcp-server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-server
+  namespace: bbs
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: bbs-mcp.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-server
+                port:
+                  number: 8080


### PR DESCRIPTION
## Summary
- Deploy `ghcr.io/toof-jp/bbs-mcp-server` (public MCP server, no auth) to the `bbs` namespace, exposed at `bbs-mcp.toof.jp` via cloudflare-tunnel Ingress
- Upstream: `http://search-backend.bbs.svc.cluster.local:3000`

⚠️ Merge after toof-jp/bbs#75 so the image exists on GHCR. Image is initially `latest`; pin to a `sha-*` tag after the first CI run to match the repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)