### PR TITLE
fix: add trailing slash to obsidian MCP resource identifier

### DIFF
--- a/kubernetes/applications/mcp-gate/README.md
+++ b/kubernetes/applications/mcp-gate/README.md
@@ -14,7 +14,7 @@ Cloudflare Access (Managed OAuth for MCP) cannot front this hostname: the claude
 
 ## Auth0 Manual Settings
 
-- Tenant Settings -> Advanced -> enable **Resource Parameter Compatibility Profile**. The MCP spec (RFC 8707) makes Claude send a `resource` parameter, and without this profile Auth0 ignores it and issues an opaque access token that `mcp-gate` cannot validate. With it enabled, the token is a JWT with `aud` = `https://obsidian-mcp.toof.jp` (the `obsidian-mcp-api` resource server identifier).
+- Tenant Settings -> Advanced -> enable **Resource Parameter Compatibility Profile**. The MCP spec (RFC 8707) makes Claude send a `resource` parameter, and without this profile Auth0 ignores it and issues an opaque access token that `mcp-gate` cannot validate. With it enabled, the token is a JWT with `aud` = `https://obsidian-mcp.toof.jp/` (the `obsidian-mcp-api` resource server identifier — the trailing slash matters, because Claude canonicalizes the resource URI to the origin with a trailing slash and Auth0 matches identifiers by exact string).
 - Enable the Social Connection you want to use, such as Google or GitHub.
 - In the `obsidian-mcp` Auth0 Application, add `https://claude.ai` to Allowed Web Origins.
 

--- a/kubernetes/applications/mcp-gate/mcp-gate.yaml
+++ b/kubernetes/applications/mcp-gate/mcp-gate.yaml
@@ -37,7 +37,7 @@ metadata:
   namespace: mcp-gate
 data:
   LISTEN_ADDR: 0.0.0.0:8080
-  RESOURCE_URI: https://obsidian-mcp.toof.jp
+  RESOURCE_URI: https://obsidian-mcp.toof.jp/
   UPSTREAM_URL: http://obsidian-msp.obsidian-msp.svc.cluster.local:3001
 ---
 apiVersion: apps/v1

--- a/terraform/mcp.tf
+++ b/terraform/mcp.tf
@@ -28,9 +28,12 @@ resource "auth0_client_credentials" "obsidian_mcp" {
   authentication_method = "client_secret_post"
 }
 
+# Claude sends the RFC 8707 resource parameter as the canonical origin URI
+# with a trailing slash; Auth0 matches API identifiers by exact string, so
+# the identifier must carry the slash too.
 resource "auth0_resource_server" "obsidian_mcp" {
   name                 = "obsidian-mcp-api"
-  identifier           = local.obsidian_mcp_url
+  identifier           = "${local.obsidian_mcp_url}/"
   signing_alg          = "RS256"
   allow_offline_access = true
 }


### PR DESCRIPTION
## 問題

Claude コネクタの接続が Auth0 の `/authorize` で失敗:

```
"resource": "https://obsidian-mcp.toof.jp/"
"error": "Service not found: https://obsidian-mcp.toof.jp/"
```

Claude は RFC 8707 の `resource` パラメータを **origin + 末尾スラッシュ** に正規化して送るが、Auth0 は API identifier を文字列完全一致で解決するため、スラッシュなしの identifier `https://obsidian-mcp.toof.jp` にマッチしなかった。

## 修正

3箇所を末尾スラッシュ付き `https://obsidian-mcp.toof.jp/` に統一:

- Auth0 resource server の `identifier`(replace になる)
- mcp-gate の `RESOURCE_URI`(protected resource metadata の `resource`)
- `EXPECTED_AUDIENCE` は `obsidian_mcp_audience` output 経由で追従(1Password の `mcp-gate/obsidian/expected-audience` の手動更新が必要)

## マージ後の手順

- [ ] 1Password `mcp-gate` アイテムの `obsidian/expected-audience` を `https://obsidian-mcp.toof.jp/` に更新
- [ ] `kubectl delete secret mcp-gate-obsidian-secret -n mcp-gate` + ExternalSecret 再同期 + `kubectl rollout restart deploy/mcp-gate-obsidian -n mcp-gate`
- [ ] Claude でコネクタを再追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)