### PR TITLE
feat: add always-on Obsidian pod bridging Obsidian Sync to git

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -32,6 +32,8 @@ spec:
             namespace: mcp-gate
           - name: npm-stats
             namespace: npm-stats
+          - name: obsidian
+            namespace: obsidian
           - name: obsidian-msp
             namespace: obsidian-msp
   template:

--- a/kubernetes/applications/obsidian/README.md
+++ b/kubernetes/applications/obsidian/README.md
@@ -1,0 +1,88 @@
+# Obsidian Sync → Git Bridge
+
+Always-on Obsidian (linuxserver/obsidian, KasmVNC GUI) running in the cluster. It joins Obsidian Sync as one more device and pushes the vault to GitHub via the obsidian-git plugin on a schedule.
+
+```text
+Mobile/Mac ⇄ Obsidian Sync ⇄ this pod → git push → github.com/toof-jp/non-demagogue
+```
+
+The git side is a read mirror. Nothing writes back into the vault through git; the cluster's `obsidian-msp` reader keeps pulling the repo as before.
+
+## Security
+
+`https://obsidian-gui.toof.jp` is a full-access GUI to the vault (and to the Obsidian Sync account). It MUST stay behind Cloudflare Access.
+
+- The Access application (`obsidian_gui` in `terraform/access.tf`, GitHub IdP, `allow-github-toof` policy) is part of the same change set as the Ingress.
+- Do not deploy the Ingress without the Access application applied. Terraform auto-applies on merge to main, but verify before first use: opening `https://obsidian-gui.toof.jp` in a private browser window must show the Cloudflare Access GitHub login, not the KasmVNC screen.
+
+## Deploy
+
+ArgoCD picks up this directory via the ApplicationSet entry (`obsidian`). Merging to main deploys everything except the two manual steps below (SSH key secret, in-GUI setup).
+
+## SSH Deploy Key (manual, before first git push)
+
+1. Generate a key pair and grab known_hosts:
+
+   ```sh
+   ssh-keygen -t ed25519 -f obsidian-git -N "" -C "obsidian-k8s"
+   ssh-keyscan github.com > known_hosts
+   ```
+
+2. GitHub → `toof-jp/non-demagogue` → Settings → Deploy keys → Add deploy key:
+   - Title: `obsidian-k8s`
+   - Key: contents of `obsidian-git.pub`
+   - **Allow write access: ON**
+
+3. 1Password (vault `infra`): create an item named `obsidian` (Secure Note), add a section `git-ssh` with two multiline text fields:
+   - `id_ed25519`: contents of the private key file `obsidian-git`
+   - `known_hosts`: contents of `known_hosts`
+
+   The ExternalSecret resolves `op://infra/obsidian/git-ssh/<field>` and mounts the result at `/config/.ssh` (read-only, root-owned, group `1000` readable — OpenSSH accepts this because the file is not owned by the running user).
+
+4. Delete the local key files.
+
+## First-Time Setup (manual, via the GUI)
+
+1. Open `https://obsidian-gui.toof.jp` (through Cloudflare Access).
+2. In Obsidian, create the vault at `/config/vaults/main`, log in to Obsidian Sync, connect to the remote vault, and wait for the initial sync to finish.
+3. Open a terminal in the KasmVNC session:
+
+   ```sh
+   cd /config/vaults/main
+   git init
+   git remote add origin git@github.com:toof-jp/non-demagogue.git
+   git config user.name "obsidian-k8s"
+   git config user.email "obsidian-k8s@toof.jp"
+   git fetch origin
+   git checkout -B main origin/main 2>/dev/null || git checkout -b main
+   ```
+
+   (If the vault content should replace the existing repo history instead of merging onto it, skip the fetch/checkout and just commit-push from the plugin.)
+
+4. Create `.gitignore` in the vault root:
+
+   ```text
+   .obsidian/workspace.json
+   .obsidian/workspace-mobile.json
+   .obsidian/plugins/*/data.json
+   .trash/
+   ```
+
+5. Install the community plugin **Git** (obsidian-git) and configure:
+   - Auto commit-and-sync interval: 10 minutes
+   - Pull before push: ON
+
+## Restart Resilience Check
+
+```sh
+kubectl rollout restart deploy/obsidian -n obsidian
+kubectl rollout status deploy/obsidian -n obsidian
+```
+
+Then in the GUI: Obsidian should reopen the vault automatically (state lives on the `obsidian-config` PVC), Obsidian Sync should reconnect on its own, and within one interval the Git plugin should commit-and-sync again — verify with `git log -1` in the vault or a fresh commit on GitHub. The SSH key survives restarts because it comes from the Secret mount, not the PVC.
+
+## Notes
+
+- `DOCKER_MODS=linuxserver/mods:universal-package-install` + `INSTALL_PACKAGES=git|openssh-client` installs git/ssh at container start; first boot takes a bit longer.
+- `seccompProfile: Unconfined` is required for Electron's sandbox inside the container. If Obsidian still fails to start, the fallback is adding the `SYS_ADMIN` capability instead.
+- `strategy: Recreate` is required because the config volume is a ReadWriteOnce PVC.

--- a/kubernetes/applications/obsidian/ingress.yaml
+++ b/kubernetes/applications/obsidian/ingress.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: obsidian
+  namespace: obsidian
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: obsidian-gui.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: obsidian
+                port:
+                  number: 3000

--- a/kubernetes/applications/obsidian/obsidian.yaml
+++ b/kubernetes/applications/obsidian/obsidian.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: obsidian
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: obsidian-git-ssh
+  namespace: obsidian
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: 1password-sdk
+    kind: ClusterSecretStore
+  target:
+    name: obsidian-git-ssh
+  data:
+    - secretKey: id_ed25519
+      remoteRef:
+        key: obsidian/git-ssh/id_ed25519
+    - secretKey: known_hosts
+      remoteRef:
+        key: obsidian/git-ssh/known_hosts
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: obsidian-config
+  namespace: obsidian
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: obsidian
+  namespace: obsidian
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: obsidian
+  template:
+    metadata:
+      labels:
+        app: obsidian
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: obsidian
+          image: lscr.io/linuxserver/obsidian:1.12.7
+          securityContext:
+            seccompProfile:
+              type: Unconfined
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: Asia/Tokyo
+            - name: DOCKER_MODS
+              value: linuxserver/mods:universal-package-install
+            - name: INSTALL_PACKAGES
+              value: git|openssh-client
+          ports:
+            - name: http
+              containerPort: 3000
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: git-ssh
+              mountPath: /config/.ssh
+              readOnly: true
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: obsidian-config
+        - name: git-ssh
+          secret:
+            secretName: obsidian-git-ssh
+            defaultMode: 0400
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: obsidian
+  namespace: obsidian
+spec:
+  selector:
+    app: obsidian
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http

--- a/terraform/access.tf
+++ b/terraform/access.tf
@@ -142,3 +142,22 @@ resource "cloudflare_zero_trust_access_application" "grafana" {
     }
   ]
 }
+
+resource "cloudflare_zero_trust_access_application" "obsidian_gui" {
+  account_id       = var.cloudflare_account_id
+  name             = "obsidian-gui"
+  domain           = "obsidian-gui.toof.jp"
+  type             = "self_hosted"
+  session_duration = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.github.id
+  ]
+
+  policies = [
+    {
+      id         = cloudflare_zero_trust_access_policy.allow_github_toof.id
+      precedence = 1
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

クラスタ上に常駐 Obsidian(`lscr.io/linuxserver/obsidian`, KasmVNC GUI)を立て、Obsidian Sync の1デバイスとして参加させて、obsidian-git プラグインで vault を GitHub に定期 push するブリッジを追加する。

```
モバイル/Mac ⇄ Obsidian Sync ⇄ k8s上のObsidian → git push → non-demagogue → git-sync → obsidian-msp (Claude MCP)
```

Mac が起動していなくてもモバイル編集が GitHub(と MCP)に届くようになる。git 側は読み取りミラーで、git 経由の書き戻しはしない設計。

## 内容

- `kubernetes/applications/obsidian/`: Namespace / PVC(10Gi RWO)/ Deployment / Service / Ingress / ExternalSecret / README
  - `strategy: Recreate`(RWO PVC のため)
  - `seccompProfile: Unconfined`(Electron sandbox 都合。ダメなら SYS_ADMIN にフォールバック)
  - `DOCKER_MODS: universal-package-install` で起動時に git / openssh-client を導入
  - SSH deploy key は 1Password(`op://infra/obsidian/git-ssh/*`)から ExternalSecret で `/config/.ssh` にマウント(root所有 0440、OpenSSH は他者所有ファイルなら許容)
  - image は `1.12.7` にピン留め(Renovate 管理)
- `applicationset.yaml`: `obsidian` エントリ追加
- `terraform/access.tf`: **Cloudflare Access アプリ `obsidian-gui.toof.jp`**(GitHub IdP + allow-github-toof)。GUI は vault フルアクセスなので Access 必須

## ⚠️ マージ前チェックリスト

- [x] SSH 鍵ペア生成済み(`ssh-keygen -t ed25519 -f obsidian-git -N "" -C "obsidian-k8s"`)
- [x] `non-demagogue` に deploy key 登録済み(**Allow write access ON**)
- [x] 1Password `infra` vault にアイテム `obsidian` / セクション `git-ssh` / フィールド `id_ed25519`・`known_hosts` 作成済み

## マージ後

- [ ] シークレットウィンドウで `https://obsidian-gui.toof.jp` を開き、**Cloudflare Access のログイン画面が出ること**を確認(terraform apply 完了前に VNC が見えたら即クローズ)
- [ ] VNC 経由の初期セットアップ(vault 作成 → Obsidian Sync 接続 → git init/remote → .gitignore → Git プラグイン設定)— 手順は `kubernetes/applications/obsidian/README.md`
- [ ] `kubectl rollout restart deploy/obsidian -n obsidian` 後に Sync と自動コミットが自走することを確認

## 検証

- `terraform validate` / `terraform fmt -check` 通過
- `kubectl apply --dry-run=client` 全リソース通過
- `prettier --check`(format-yaml CI と同一)通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)