### PR TITLE
fix: give obsidian pod a 1Gi /dev/shm

### DIFF
--- a/kubernetes/applications/obsidian/obsidian.yaml
+++ b/kubernetes/applications/obsidian/obsidian.yaml
@@ -80,13 +80,15 @@ spec:
               cpu: 250m
               memory: 1Gi
             limits:
-              memory: 2Gi
+              memory: 3Gi
           volumeMounts:
             - name: config
               mountPath: /config
             - name: git-ssh
               mountPath: /config/.ssh
               readOnly: true
+            - name: dshm
+              mountPath: /dev/shm
       volumes:
         - name: config
           persistentVolumeClaim:
@@ -95,6 +97,10 @@ spec:
           secret:
             secretName: obsidian-git-ssh
             defaultMode: 0400
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## 問題

`obsidian-gui.toof.jp` のストリームが全ブラウザ(Brave / Safari)で真っ黒。X ウィンドウを直接キャプチャするとアプリ自体は正常に描画されており(vault 選択画面表示)、キャプチャ→配信経路の問題と特定。

## 原因

k8s の Pod は `/dev/shm` がデフォルト 64Mi。linuxserver/obsidian は `shm_size: "1gb"` を必須と明記しており、Selkies/pixelflux のフレームバッファ(3056x2108 BGRA ≈ 25MB/frame)が確保できず黒フレームになる。

## 修正

- `emptyDir(medium: Memory, sizeLimit: 1Gi)` を `/dev/shm` にマウント
- tmpfs 使用分は cgroup のメモリにカウントされるため limits.memory を 2Gi → 3Gi に引き上げ

マージ後は Recreate で Pod が作り直されます。`df -h /dev/shm` が 1G になっていることと、GUI の表示を確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)