### PR TITLE
fix: restart mcpvault when git-sync swaps the vault worktree

### DIFF
--- a/kubernetes/applications/obsidian-msp/obsidian-msp.yaml
+++ b/kubernetes/applications/obsidian-msp/obsidian-msp.yaml
@@ -55,10 +55,24 @@ spec:
               until [ -e /git/vault ]; do
                 sleep 1
               done
+              readlink -f /git/vault > /tmp/vault-path
               exec npx --yes mcp-proxy@6.5.2 --port 3001 -- npx --yes @bitbonsai/mcpvault@0.11.0 /git/vault
           ports:
             - name: http-mcp
               containerPort: 3001
+          readinessProbe:
+            tcpSocket:
+              port: http-mcp
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - '[ ! -f /tmp/vault-path ] || [ "$(readlink -f /git/vault)" = "$(cat /tmp/vault-path)" ]'
+            initialDelaySeconds: 30
+            periodSeconds: 30
           volumeMounts:
             - name: obsidian-vault
               mountPath: /git


### PR DESCRIPTION
## Problem

Obsidian MCP was returning ENOENT for every tool call while the connection itself still worked:

```
Error: ENOENT: no such file or directory, scandir '/git/root/.worktrees/5dd2477b...'
```

mcpvault resolves the `/git/vault` symlink to its real worktree path at startup and caches it. When a new commit lands in the vault repo, git-sync creates a new worktree, repoints the symlink, and immediately deletes the old worktree (`--stale-worktree-timeout` defaults to 0). mcpvault keeps scanning the deleted directory until the pod is restarted. MCP initialize succeeds (no file access), so the failure only shows up on tool calls.

## Fix

- Record the resolved vault path at container startup and add an exec liveness probe that fails once `readlink -f /git/vault` no longer matches it — kubelet restarts the container onto the new worktree automatically.
- Add a TCP readiness probe on port 3001 so traffic isn't routed to the pod while `npx` is still downloading packages after a (re)start.

The probe passes while `/tmp/vault-path` doesn't exist yet, so the initial git-sync clone wait doesn't trigger restart loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)