### PR TITLE
feat: immichをhelm chartと専用postgresでデプロイ

### DIFF
--- a/kubernetes/applications/immich.yaml
+++ b/kubernetes/applications/immich.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: immich
+  namespace: argocd
+spec:
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  sources:
+    - repoURL: https://github.com/toof-jp/infra
+      targetRevision: HEAD
+      path: kubernetes/applications/immich
+    - chart: immich
+      repoURL: https://immich-app.github.io/immich-charts
+      targetRevision: 0.12.0
+      helm:
+        valuesObject:
+          defaultPodOptions:
+            nodeSelector:
+              kubernetes.io/hostname: zen2
+          controllers:
+            main:
+              containers:
+                main:
+                  env:
+                    DB_HOSTNAME: postgres
+                    DB_USERNAME: immich
+                    DB_DATABASE_NAME: immich
+                    DB_PASSWORD:
+                      valueFrom:
+                        secretKeyRef:
+                          name: postgres-secret
+                          key: POSTGRES_PASSWORD
+          immich:
+            persistence:
+              library:
+                existingClaim: immich-library
+          valkey:
+            enabled: true
+          server:
+            ingress:
+              main:
+                enabled: true
+                className: cloudflare-tunnel
+                hosts:
+                  - host: immich.toof.jp
+                    paths:
+                      - path: /
+                        service:
+                          identifier: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: immich

--- a/kubernetes/applications/immich.yaml
+++ b/kubernetes/applications/immich.yaml
@@ -49,7 +49,7 @@ spec:
                 enabled: true
                 className: cloudflare-tunnel
                 hosts:
-                  - host: immich.toof.jp
+                  - host: photo.toof.jp
                     paths:
                       - path: /
                         service:

--- a/kubernetes/applications/immich/external-secret.yaml
+++ b/kubernetes/applications/immich/external-secret.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-external-secret
+  namespace: immich
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: postgres-secret
+    template:
+      type: Opaque
+      data:
+        POSTGRES_USER: immich
+        POSTGRES_DB: immich
+        POSTGRES_PASSWORD: "{{ .password }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: ClusterGenerator
+          name: password

--- a/kubernetes/applications/immich/postgres.yaml
+++ b/kubernetes/applications/immich/postgres.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: immich
+  labels:
+    app: postgres
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: immich
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: zen2
+      containers:
+        - name: postgres
+          image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_INITDB_ARGS
+              value: --data-checksums
+          envFrom:
+            - secretRef:
+                name: postgres-secret
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 128Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 10Gi

--- a/kubernetes/applications/immich/pvc.yaml
+++ b/kubernetes/applications/immich/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-library
+  namespace: immich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 50Gi


### PR DESCRIPTION
## 概要

immich(セルフホスト写真管理)をクラスタに追加する。app-of-appsが拾うスタンドアロンのmulti-source Applicationとして構成:

- **helm chart** `immich 0.12.0`(app `v2.6.3`、最新)— server / machine-learning / valkey
- **ローカルmanifest** — VectorChord入りpostgres StatefulSet、ライブラリ用PVC(Longhorn 50Gi)、ExternalSecret

## 構成のポイント

- **postgres**: `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0` — immich v2.6.3公式docker-composeとイメージ・環境変数ともに一致
- **DBパスワード**: bbsと同じくClusterGenerator `password` で生成し、`postgres-secret` に格納。serverは `secretKeyRef` で参照
- **volumeマウント**: PGDATAの親 `/var/lib/postgresql` をマウント(bbsと同じパターン)。Longhornの新規ext4ボリュームにある `lost+found` でinitdbが失敗するのを回避
- **ノード固定**: `defaultPodOptions.nodeSelector` とStatefulSetの `nodeSelector` で全コンポーネントをzen2に配置(kube-prometheus-stackと同じパターン)。machine-learningとサムネイル生成はVPSノード(RAM 2-4GB)には重すぎるため
- **ingress**: `cloudflare-tunnel` で `immich.toof.jp` を公開

## 検証

`helm template` (chart 0.12.0) でレンダリング確認済み:

- nodeSelectorが3コンポーネント(server / machine-learning / valkey)すべてに伝播
- `DB_*` envと `secretKeyRef`、`REDIS_HOSTNAME=immich-valkey`、`IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003` がサービス名と一致
- ingressClassName / host / existingClaimが期待どおり

🤖 Generated with [Claude Code](https://claude.com/claude-code)