### PR TITLE
fix: bbs の postgres ExternalSecret が存在しない ClusterGenerator を参照している問題を修正

### DIFF
--- a/kubernetes/applications/bbs/external-secret.yaml
+++ b/kubernetes/applications/bbs/external-secret.yaml
@@ -81,7 +81,7 @@ spec:
         generatorRef:
           apiVersion: generators.external-secrets.io/v1alpha1
           kind: ClusterGenerator
-          name: "postgres-password"
+          name: password
 ---
 apiVersion: generators.external-secrets.io/v1alpha1
 kind: ClusterGenerator


### PR DESCRIPTION
## 概要

`postgres-external-secret` の `generatorRef` が `postgres-password` という名前の ClusterGenerator を参照していますが、実際に存在する ClusterGenerator の名前は `password` です。

`refreshPolicy: CreatedOnce` のため、既存の `postgres-secret` がある間は表面化しませんが、Secret を再作成する必要が生じた場合に生成が失敗します。参照名を実名に合わせて修正します。

## 影響

- 既存 Secret には変更なし（CreatedOnce のため再生成は発生しません）

🤖 Generated with [Claude Code](https://claude.com/claude-code)