### PR TITLE
feat: import dev VM root disk from GCS via CDI

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -16,6 +16,8 @@ spec:
             namespace: bbs
           - name: blues
             namespace: blues
+          - name: cdi
+            namespace: cdi
           - name: cloudflare-external-secret
             namespace: cloudflare
           - name: dev-vm

--- a/kubernetes/applications/cdi/cdi-cr.yaml
+++ b/kubernetes/applications/cdi/cdi-cr.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: CDI
+metadata:
+  name: cdi
+  namespace: cdi
+spec: {}

--- a/kubernetes/applications/cdi/kustomization.yaml
+++ b/kubernetes/applications/cdi/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.65.0/cdi-operator.yaml
+  - cdi-cr.yaml

--- a/kubernetes/applications/dev-vm/vm.yaml
+++ b/kubernetes/applications/dev-vm/vm.yaml
@@ -19,6 +19,23 @@ metadata:
   namespace: dev-vm
 spec:
   runStrategy: Always
+  # Root disk is imported once by CDI from GCS (built locally from
+  # toof-jp/dotfiles nix/#kubevirt-image and uploaded); to roll out a new
+  # image, upload it and delete the dev-root DataVolume to re-import.
+  dataVolumeTemplates:
+    - metadata:
+        name: dev-root
+      spec:
+        storage:
+          accessModes:
+            - ReadWriteOnce
+          storageClassName: longhorn
+          resources:
+            requests:
+              storage: 70Gi
+        source:
+          http:
+            url: https://storage.googleapis.com/toof-infra-vm-images/nixos-dev.qcow2
   template:
     metadata:
       labels:
@@ -52,8 +69,8 @@ spec:
           pod: {}
       volumes:
         - name: root
-          containerDisk:
-            image: ghcr.io/toof-jp/nixos-dev:main
+          dataVolume:
+            name: dev-root
         - name: home
           persistentVolumeClaim:
             claimName: dev-home


### PR DESCRIPTION
## Summary
- Add CDI (containerized-data-importer) v1.65.0 operator + CR as an ArgoCD application
- Switch the `dev` VM root disk from a ghcr containerDisk to a CDI DataVolume imported over HTTP from `gs://toof-infra-vm-images/nixos-dev.qcow2` (built locally with `nix build .#kubevirt-image` in toof-jp/dotfiles)

## Notes
- The root disk becomes a persistent Longhorn PVC (70Gi, thin-provisioned); to roll out a new image, upload a new qcow2 and delete the `dev-root` DataVolume
- The image object is public-read (it contains only nix-store content derived from the public dotfiles repo; SSH access is via public keys baked into the image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)