### PR TITLE
Renovateでk8sマニフェストのDockerイメージとArgoCD Helmチャートを更新対象にする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "kubernetes": {
+    "managerFilePatterns": [
+      "/^kubernetes/.+\\.yaml$/"
+    ]
+  },
+  "argocd": {
+    "managerFilePatterns": [
+      "/^kubernetes/applications/.+\\.yaml$/"
+    ]
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchCurrentValue": "latest",
+      "pinDigests": true
+    }
   ]
 }


### PR DESCRIPTION
## 概要
Renovate自体は既に有効(Terraform / GitHub Actions / npm のPRは作成済み)でしたが、`config:recommended` のみの設定では `kubernetes/` 配下のマニフェストが検出対象外だったため、以下を追加しました。

## 変更内容
- `kubernetes` マネージャーを有効化: `kubernetes/**/*.yaml` 内のコンテナイメージ(nginx, postgres, ghcr.io のイメージ等)を更新対象にする
- `argocd` マネージャーを有効化: `kubernetes/applications/` 配下の ArgoCD Application の Helm チャート(longhorn, kube-prometheus-stack 等)の `targetRevision` を更新対象にする
- `latest` タグのイメージはダイジェスト固定(`latest@sha256:...`)する packageRule を追加。対象は以下の2つで、固定後はダイジェスト更新PRが作成されます
  - `atdr.meo.ws/archiveteam/warrior-dockerfile:latest`
  - `ghcr.io/toof-jp/bbs-mcp-server:latest`

なお、kustomization.yaml のリモートリソース(kubevirt / CDI のリリースURL)は `config:recommended` 標準の kustomize マネージャーで既に検出可能です。`sha-xxxxxxx` 形式のタグはバージョン比較不能のため対象外です。

`renovate-config-validator` での検証済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)