### PR TITLE
chore: vultr-vpsのプランをvhp-2c-4gb-amdにアップグレード

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -74,8 +74,8 @@ variable "vultr_region" {
 
 variable "vultr_plan" {
   type        = string
-  description = "Vultr plan ID. vhp-1c-2gb-amd = High Performance AMD 1vCPU/2GB."
-  default     = "vhp-1c-2gb-amd"
+  description = "Vultr plan ID. vhp-2c-4gb-amd = High Performance AMD 2vCPU/4GB."
+  default     = "vhp-2c-4gb-amd"
 }
 
 variable "vultr_iso_url" {


### PR DESCRIPTION
## 概要

vultr-vps を `vhp-1c-2gb-amd` (1vCPU/2GB, $12/月) から `vhp-2c-4gb-amd` (2vCPU/4GB/100GB, $24/月) にアップグレードします。

## 背景

vultr-vps がリソース枯渇で NotReady になり、ノード上の全コンポーネントが再起動ループに陥っていました。

- 1 vCPU に対しロードアベレージ 32
- メモリ残 164Mi・スワップなし(kube-apiserver 単体で RAM の 41% を消費)
- probe / TLS handshake のタイムアウト多発により kube-apiserver 210回、kube-scheduler 204回、etcd 129回、node-exporter 289回(27時間)の再起動

control-plane + etcd + Longhorn を同居させるには 2GB では不足のため、4GB プランに引き上げます。

## 注意

- アップグレードは in-place リサイズ(要再起動)
- ディスクが 50GB→100GB に拡張されるため、適用後のダウングレードは不可

🤖 Generated with [Claude Code](https://claude.com/claude-code)