### PR TITLE
feat: Immich MCPサーバーをmcp-gate経由で追加

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -26,6 +26,8 @@ spec:
             namespace: external-secrets
           - name: healthcheck
             namespace: healthcheck
+          - name: immich-mcp
+            namespace: immich-mcp
           - name: kubevirt
             namespace: kubevirt
           - name: shisha-log

--- a/kubernetes/applications/immich-mcp/immich-mcp.yaml
+++ b/kubernetes/applications/immich-mcp/immich-mcp.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: immich-mcp
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: immich-mcp
+  namespace: immich-mcp
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: immich-mcp-secret
+  data:
+    - secretKey: IMMICH_API_KEY
+      remoteRef:
+        key: immich-mcp-api-key
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: immich-mcp-config
+  namespace: immich-mcp
+data:
+  IMMICH_BASE_URL: http://immich-server.immich.svc.cluster.local:2283
+  MCP_PORT: "5000"
+  DOWNLOAD_MODE: base64
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: immich-mcp
+  namespace: immich-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: immich-mcp
+  template:
+    metadata:
+      labels:
+        app: immich-mcp
+    spec:
+      containers:
+        - name: immich-mcp
+          image: ghcr.io/barryw/immichmcp:v0.4.0
+          ports:
+            - name: http
+              containerPort: 5000
+          envFrom:
+            - configMapRef:
+                name: immich-mcp-config
+            - secretRef:
+                name: immich-mcp-secret
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich-mcp
+  namespace: immich-mcp
+spec:
+  selector:
+    app: immich-mcp
+  ports:
+    - name: http
+      port: 5000
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: immich-mcp
+  namespace: immich-mcp
+spec:
+  podSelector:
+    matchLabels:
+      app: immich-mcp
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-gate
+          podSelector:
+            matchLabels:
+              app: mcp-gate-immich
+      ports:
+        - protocol: TCP
+          port: 5000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: immich
+      ports:
+        - protocol: TCP
+          port: 2283
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/kubernetes/applications/mcp-gate/README.md
+++ b/kubernetes/applications/mcp-gate/README.md
@@ -57,3 +57,36 @@ In Claude:
 The gateway points to `http://obsidian-msp.obsidian-msp.svc.cluster.local:3001`.
 
 `@bitbonsai/mcpvault` is a stdio-only MCP server, so the `obsidian-msp` Deployment wraps it with `mcp-proxy`, which serves Streamable HTTP at `/mcp` (and SSE at `/sse`) on port 3001.
+
+## Immich MCP Gateway
+
+`immich.yaml` exposes the Immich MCP endpoint at:
+
+```text
+https://immich-mcp.toof.jp/mcp
+```
+
+The upstream is [barryw/ImmichMCP](https://github.com/barryw/ImmichMCP) running in the `immich-mcp` namespace (`kubernetes/applications/immich-mcp/`), serving Streamable HTTP at `/mcp` on port 5000. ImmichMCP 3.x targets Immich v3 APIs, so the image is pinned to `v0.4.0` until the Immich chart is upgraded past v2.
+
+### Secret Values
+
+Populate the `mcp-gate/immich/*` 1Password items from Terraform outputs:
+
+- `mcp-gate/immich/authorization-server`: `terraform output -raw auth0_obsidian_mcp_issuer`
+- `mcp-gate/immich/jwks-uri`: `terraform output -raw auth0_obsidian_mcp_jwks_uri`
+- `mcp-gate/immich/expected-issuer`: `terraform output -raw auth0_obsidian_mcp_issuer`
+- `mcp-gate/immich/expected-audience`: `terraform output -raw immich_mcp_audience`
+
+The Immich API key comes from GCP Secret Manager (`immich-mcp-api-key`). Create it in Immich (Account Settings -> API Keys) with read-only permissions only; ImmichMCP has no read-only mode, so the key permissions are what enforce it.
+
+### Auth0 Manual Settings
+
+In the `immich-mcp` Auth0 Application, add `https://claude.ai` to Allowed Web Origins. The tenant-wide Resource Parameter Compatibility Profile is already enabled for obsidian-mcp.
+
+### Claude Connector
+
+1. Settings -> Connectors -> Add Custom Connector
+2. Remote MCP server URL: `https://immich-mcp.toof.jp/mcp`
+3. Advanced settings -> OAuth Client ID: `terraform output -raw auth0_immich_mcp_client_id`
+4. Advanced settings -> OAuth Client Secret: `terraform output -raw auth0_immich_mcp_client_secret`
+5. Add, sign in on the Auth0 screen, and finish the connector setup.

--- a/kubernetes/applications/mcp-gate/immich.yaml
+++ b/kubernetes/applications/mcp-gate/immich.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mcp-gate-immich
+  namespace: mcp-gate
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: 1password-sdk
+    kind: ClusterSecretStore
+  target:
+    name: mcp-gate-immich-secret
+  data:
+    - secretKey: AUTHORIZATION_SERVER
+      remoteRef:
+        key: mcp-gate/immich/authorization-server
+    - secretKey: JWKS_URI
+      remoteRef:
+        key: mcp-gate/immich/jwks-uri
+    - secretKey: EXPECTED_ISSUER
+      remoteRef:
+        key: mcp-gate/immich/expected-issuer
+    - secretKey: EXPECTED_AUDIENCE
+      remoteRef:
+        key: mcp-gate/immich/expected-audience
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-gate-immich-config
+  namespace: mcp-gate
+data:
+  LISTEN_ADDR: 0.0.0.0:8080
+  RESOURCE_URI: https://immich-mcp.toof.jp/
+  UPSTREAM_URL: http://immich-mcp.immich-mcp.svc.cluster.local:5000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-gate-immich
+  namespace: mcp-gate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-gate-immich
+  template:
+    metadata:
+      labels:
+        app: mcp-gate-immich
+    spec:
+      containers:
+        - name: mcp-gate
+          image: cpremus/mcp-gate:0.16.27
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: mcp-gate-immich-config
+            - secretRef:
+                name: mcp-gate-immich-secret
+          readinessProbe:
+            httpGet:
+              path: /.well-known/oauth-protected-resource
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /.well-known/oauth-protected-resource
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-gate-immich
+  namespace: mcp-gate
+spec:
+  selector:
+    app: mcp-gate-immich
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-gate-immich
+  namespace: mcp-gate
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: immich-mcp.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-gate-immich
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-gate-immich
+  namespace: mcp-gate
+spec:
+  podSelector:
+    matchLabels:
+      app: mcp-gate-immich
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: immich-mcp
+          podSelector:
+            matchLabels:
+              app: immich-mcp
+      ports:
+        - protocol: TCP
+          port: 5000
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/terraform/mcp.tf
+++ b/terraform/mcp.tf
@@ -1,6 +1,8 @@
 locals {
   obsidian_mcp_hostname = "obsidian-mcp.${var.domain}"
   obsidian_mcp_url      = "https://${local.obsidian_mcp_hostname}"
+  immich_mcp_hostname   = "immich-mcp.${var.domain}"
+  immich_mcp_url        = "https://${local.immich_mcp_hostname}"
 }
 
 resource "auth0_client" "obsidian_mcp" {
@@ -40,6 +42,46 @@ resource "auth0_resource_server" "obsidian_mcp" {
 
 resource "auth0_resource_server_scopes" "obsidian_mcp" {
   resource_server_identifier = auth0_resource_server.obsidian_mcp.identifier
+  scopes {
+    name        = "mcp:tools"
+    description = "MCP tools access"
+  }
+}
+
+resource "auth0_client" "immich_mcp" {
+  name        = "immich-mcp"
+  app_type    = "regular_web"
+  description = "Claude remote MCP connector for the Immich photo library."
+
+  callbacks = [
+    "https://claude.ai/api/mcp/auth_callback",
+    "https://claude.com/api/mcp/auth_callback",
+  ]
+
+  allowed_logout_urls = []
+
+  grant_types = [
+    "authorization_code",
+    "refresh_token",
+  ]
+
+  oidc_conformant = true
+}
+
+resource "auth0_client_credentials" "immich_mcp" {
+  client_id             = auth0_client.immich_mcp.id
+  authentication_method = "client_secret_post"
+}
+
+resource "auth0_resource_server" "immich_mcp" {
+  name                 = "immich-mcp-api"
+  identifier           = "${local.immich_mcp_url}/"
+  signing_alg          = "RS256"
+  allow_offline_access = true
+}
+
+resource "auth0_resource_server_scopes" "immich_mcp" {
+  resource_server_identifier = auth0_resource_server.immich_mcp.identifier
   scopes {
     name        = "mcp:tools"
     description = "MCP tools access"

--- a/terraform/mcp_outputs.tf
+++ b/terraform/mcp_outputs.tf
@@ -33,3 +33,24 @@ output "obsidian_mcp_audience" {
   value       = auth0_resource_server.obsidian_mcp.identifier
   description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
 }
+
+output "auth0_immich_mcp_client_id" {
+  value       = auth0_client.immich_mcp.client_id
+  description = "OAuth client ID for the Claude Immich MCP connector."
+}
+
+output "auth0_immich_mcp_client_secret" {
+  value       = auth0_client_credentials.immich_mcp.client_secret
+  description = "OAuth client secret for the Claude Immich MCP connector."
+  sensitive   = true
+}
+
+output "immich_mcp_resource_uri" {
+  value       = local.immich_mcp_url
+  description = "Public URL/resource URI for the Immich MCP gateway."
+}
+
+output "immich_mcp_audience" {
+  value       = auth0_resource_server.immich_mcp.identifier
+  description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
+}


### PR DESCRIPTION
## 概要

Immich(photo.toof.jp)の写真ライブラリをClaudeから検索・閲覧できるように、[barryw/ImmichMCP](https://github.com/barryw/ImmichMCP) を `immich-mcp.toof.jp` で公開します。obsidian-mcp と同じ mcp-gate + Auth0 パターンで認証を必須にしています。

## 構成

```
Claude → https://immich-mcp.toof.jp/mcp (cloudflare-tunnel)
       → mcp-gate-immich (mcp-gate ns, Auth0 JWT検証)
       → immich-mcp (immich-mcp ns, ghcr.io/barryw/immichmcp:v0.4.0, :5000/mcp)
       → immich-server.immich:2283
```

## 変更内容

- `kubernetes/applications/immich-mcp/immich-mcp.yaml`: ImmichMCP本体(Namespace / ExternalSecret / ConfigMap / Deployment / Service / NetworkPolicy)
- `kubernetes/applications/mcp-gate/immich.yaml`: mcp-gateインスタンス + Ingress(immich-mcp.toof.jp)+ NetworkPolicy
- `kubernetes/applications/applicationset.yaml`: `immich-mcp` エントリ追加
- `terraform/mcp.tf` / `mcp_outputs.tf`: Auth0 クライアント・リソースサーバー(`https://immich-mcp.toof.jp/`)・outputs 追加
- `kubernetes/applications/mcp-gate/README.md`: immich-mcp のセットアップ手順を追記

## 設計上のポイント

- **バージョンピン**: ImmichMCP 3.x は Immich v3 API 専用のため、稼働中の Immich v2.6.3 に合わせて `v0.4.0` に固定。Immich を v3 に上げたタイミングで追従する
- **読み取り専用**: ImmichMCP に read-only モードがないため、Immich 側で読み取り系パーミッションのみの API キーを発行して強制する
- **DOWNLOAD_MODE=base64**: URL モードだとクラスタ内 URL + API キー認証が必要なリンクが返り Claude から使えないため

## マージ後の手動作業

1. HCP Terraform で apply → outputs 取得
2. 1Password `infra` vault に `mcp-gate/immich/*` アイテムを作成(マッピングは mcp-gate/README.md 参照)
3. Auth0 の `immich-mcp` Application の Allowed Web Origins に `https://claude.ai` を追加
4. Immich UI で読み取り専用 API キーを発行 → GCP Secret Manager に `immich-mcp-api-key` として登録
5. Claude のカスタムコネクタに `https://immich-mcp.toof.jp/mcp` を登録

## 検証

- `terraform fmt -check` パス
- `kubectl apply --dry-run=server`(既存 namespace 分)/ `--dry-run=client`(immich-mcp namespace 分)パス
- ghcr.io に `v0.4.0` イメージタグが存在することを確認済み
- v0.4.0 のソースで `/mcp`(Streamable HTTP)と `/health` エンドポイント、`MCP_PORT` を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)