### PR TITLE
Terraform管理のIAM権限を最小権限に絞る

### DIFF
--- a/terraform/cloud_function.tf
+++ b/terraform/cloud_function.tf
@@ -25,8 +25,8 @@ resource "google_service_account" "monitoring_function_runtime" {
   depends_on   = [google_project_service.enabled["iam.googleapis.com"]]
 }
 
-resource "google_project_iam_member" "monitoring_function_runtime_secret_accessor" {
-  project = google_project.toof_infra.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  member  = "serviceAccount:${google_service_account.monitoring_function_runtime.email}"
+resource "google_secret_manager_secret_iam_member" "monitoring_function_runtime_secret_accessor" {
+  secret_id = google_secret_manager_secret.discord_webhook_url.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.monitoring_function_runtime.email}"
 }

--- a/terraform/github_actions.tf
+++ b/terraform/github_actions.tf
@@ -65,10 +65,10 @@ resource "google_project_iam_member" "monitoring_function_deployer_run_admin" {
   member  = "serviceAccount:${google_service_account.monitoring_function_deployer.email}"
 }
 
-resource "google_project_iam_member" "monitoring_function_deployer_secret_accessor" {
-  project = google_project.toof_infra.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  member  = "serviceAccount:${google_service_account.monitoring_function_deployer.email}"
+resource "google_secret_manager_secret_iam_member" "monitoring_function_deployer_secret_accessor" {
+  secret_id = google_secret_manager_secret.discord_webhook_url.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.monitoring_function_deployer.email}"
 }
 
 resource "google_project_iam_member" "monitoring_function_deployer_sa_user" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,10 +1,85 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  terraform_user_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/terraform"
+  terraform_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/terraform-management"
+  terraform_policy_arns = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/TerraformManagementPolicy",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/TerraformUserAssumeRole",
+  ]
+}
+
 data "aws_iam_policy_document" "terraform_management" {
   statement {
-    sid     = "ManageIAM"
-    actions = ["iam:*"]
-    resources = [
-      "*"
+    sid = "ManageTerraformUser"
+    actions = [
+      "iam:CreateUser",
+      "iam:DeleteUser",
+      "iam:GetUser",
+      "iam:ListAttachedUserPolicies",
+      "iam:ListGroupsForUser",
+      "iam:ListUserPolicies",
+      "iam:ListUserTags",
+      "iam:TagUser",
+      "iam:UntagUser",
     ]
+    resources = [local.terraform_user_arn]
+  }
+
+  statement {
+    sid = "ManageTerraformRole"
+    actions = [
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:GetRole",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
+      "iam:ListRolePolicies",
+      "iam:ListRoleTags",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:UpdateRole",
+      "iam:UpdateRoleDescription",
+    ]
+    resources = [local.terraform_role_arn]
+  }
+
+  statement {
+    sid = "ManageTerraformPolicies"
+    actions = [
+      "iam:CreatePolicy",
+      "iam:CreatePolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:ListPolicyTags",
+      "iam:ListPolicyVersions",
+      "iam:SetDefaultPolicyVersion",
+      "iam:TagPolicy",
+      "iam:UntagPolicy",
+    ]
+    resources = local.terraform_policy_arns
+  }
+
+  statement {
+    sid = "AttachManagedTerraformPolicies"
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:AttachUserPolicy",
+      "iam:DetachRolePolicy",
+      "iam:DetachUserPolicy",
+    ]
+    resources = [
+      local.terraform_user_arn,
+      local.terraform_role_arn,
+    ]
+    condition {
+      test     = "ArnEquals"
+      variable = "iam:PolicyARN"
+      values   = local.terraform_policy_arns
+    }
   }
 
   statement {

--- a/terraform/service_account.tf
+++ b/terraform/service_account.tf
@@ -5,9 +5,14 @@ locals {
     "roles/logging.logWriter",
   ]
   terraform_sa_roles = [
-    "roles/editor",
-    "roles/secretmanager.secretAccessor",
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.serviceAccountKeyAdmin",
+    "roles/iam.workloadIdentityPoolAdmin",
+    "roles/monitoring.admin",
     "roles/resourcemanager.projectIamAdmin",
+    "roles/secretmanager.admin",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/storage.admin",
   ]
 }
 


### PR DESCRIPTION
## 概要

mainブランチのセキュリティ監査で検出された、IAM権限の過剰付与3件を修正します。

## 変更内容

### 1. GCP `terraform_sa` から `roles/editor` を撤廃(`service_account.tf`)

`roles/editor` + `roles/resourcemanager.projectIamAdmin` の組み合わせは、SA鍵の漏洩時に `roles/owner` 自己付与によるプロジェクト完全掌握につながります。`editor` を、Terraformが実際に管理しているリソースに対応する粒度のロール(serviceAccountAdmin / serviceAccountKeyAdmin / workloadIdentityPoolAdmin / monitoring.admin / secretmanager.admin / serviceUsageAdmin / storage.admin)に置き換えました。IAMバインディング管理に必須の `projectIamAdmin` は維持しています(`secretmanager.secretAccessor` は `secretmanager.admin` に包含されるため削除)。

### 2. AWS `terraform-management` ロールの `iam:*` on `*` を撤廃(`iam.tf`)

従来はロールを引き受けた者が `iam:AttachUserPolicy` で任意のポリシー(AdministratorAccessを含む)を付与でき、実質アカウント管理者に昇格できました。IAM操作を terraform 自身の user / role / 2つのpolicyに限定し、Attach/Detachは `iam:PolicyARN` 条件で管理対象ポリシーのみに制限しています。

### 3. `secretmanager.secretAccessor` のプロジェクト全体付与を撤廃(`github_actions.tf` / `cloud_function.tf`)

monitoring function の deployer SA(外部リポジトリからOIDCで偽装可能)と runtime SA がプロジェクト内の全シークレット(terraform SA鍵・AWSキー等)を読める状態でした。両SAとも `discord-webhook-url` シークレットへのリソースレベルバインディングに変更しています。External Secrets Operator はクラスタ全体へのシークレット供給が役割のため、プロジェクト全体のまま維持しています。

## 検証

- `terraform fmt -check` パス
- `terraform validate` パス(cloudブロックを除いたコピーで `init -backend=false` 後に実行)

## 注意点

- apply後、`monitoring-function-deployer` によるfunctionデプロイと監視通知が正常に動くことを確認してください(シークレット参照が絞られたため)
- `terraform_sa` のロール縮小により、将来 `google_project` リソース自体の属性変更(プロジェクト名やbilling変更)にはオーナー権限での操作が必要になります

🤖 Generated with [Claude Code](https://claude.com/claude-code)