### PR TITLE
refactor: k8sマニフェストのレビュー指摘を修正

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -30,18 +30,18 @@ spec:
             namespace: immich-mcp
           - name: kubevirt
             namespace: kubevirt
-          - name: shisha-log
-            namespace: shisha-log
-          - name: monitoring
-            namespace: monitoring
           - name: mcp-gate
             namespace: mcp-gate
+          - name: monitoring
+            namespace: monitoring
           - name: npm-stats
             namespace: npm-stats
           - name: obsidian
             namespace: obsidian
           - name: obsidian-msp
             namespace: obsidian-msp
+          - name: shisha-log
+            namespace: shisha-log
   template:
     metadata:
       name: "{{name}}"

--- a/kubernetes/applications/archiveteam-warrior/archiveteam-warrior.yaml
+++ b/kubernetes/applications/archiveteam-warrior/archiveteam-warrior.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: archiveteam-warrior
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +25,7 @@ spec:
             - name: SELECTED_PROJECT
               value: auto
             - name: CONCURRENT_ITEMS
-              value: "3" # default value
+              value: "3"
           livenessProbe:
             httpGet:
               path: "/info"

--- a/kubernetes/applications/archiveteam-warrior/namespace.yaml
+++ b/kubernetes/applications/archiveteam-warrior/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: archiveteam-warrior

--- a/kubernetes/applications/argocd/argocd-cmd-params-cm-patch.yaml
+++ b/kubernetes/applications/argocd/argocd-cmd-params-cm-patch.yaml
@@ -4,5 +4,4 @@ kind: ConfigMap
 metadata:
   name: argocd-cmd-params-cm
 data:
-  # Disable Argo CD's built-in TLS so Cloudflare Access can terminate HTTPS
   server.insecure: "true"

--- a/kubernetes/applications/argocd/kustomization.yaml
+++ b/kubernetes/applications/argocd/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: argocd
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.5/manifests/install.yaml
   - ingress.yaml
 patches:
   - target:

--- a/kubernetes/applications/bbs/external-secret.yaml
+++ b/kubernetes/applications/bbs/external-secret.yaml
@@ -83,20 +83,6 @@ spec:
           kind: ClusterGenerator
           name: password
 ---
-apiVersion: generators.external-secrets.io/v1alpha1
-kind: ClusterGenerator
-metadata:
-  name: password
-spec:
-  kind: Password
-  generator:
-    passwordSpec:
-      length: 42
-      digits: 0
-      symbols: 0
-      symbolCharacters: ""
-      allowRepeat: true
----
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/applications/bbs/mcp-server.yaml
+++ b/kubernetes/applications/bbs/mcp-server.yaml
@@ -21,7 +21,7 @@ spec:
               containerPort: 8080
           env:
             - name: BACKEND_BASE_URL
-              value: http://search-backend.bbs.svc.cluster.local:3000
+              value: http://search-backend:3000
           readinessProbe:
             httpGet:
               path: /healthz

--- a/kubernetes/applications/cloudflare-external-secret/namespace.yaml
+++ b/kubernetes/applications/cloudflare-external-secret/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudflare

--- a/kubernetes/applications/dev-vm/ghcr-auth.yaml
+++ b/kubernetes/applications/dev-vm/ghcr-auth.yaml
@@ -13,6 +13,7 @@ metadata:
   name: ghcr-auth
   namespace: dev-vm
 spec:
+  refreshPolicy: CreatedOnce
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/dev-vm/vm.yaml
+++ b/kubernetes/applications/dev-vm/vm.yaml
@@ -19,9 +19,6 @@ metadata:
   namespace: dev-vm
 spec:
   runStrategy: Always
-  # Root disk is imported once by CDI from GCS (built locally from
-  # toof-jp/dotfiles nix/#kubevirt-image and uploaded); to roll out a new
-  # image, upload it and delete the dev-root DataVolume to re-import.
   dataVolumeTemplates:
     - metadata:
         name: dev-root
@@ -41,7 +38,6 @@ spec:
       labels:
         kubevirt.io/vm: dev
     spec:
-      # Only zen2 has /dev/kvm
       nodeSelector:
         kubernetes.io/hostname: zen2
       domain:
@@ -55,7 +51,7 @@ spec:
               disk:
                 bus: virtio
             - name: home
-              serial: home # NixOS mounts /dev/disk/by-id/virtio-home at /home
+              serial: home
               disk:
                 bus: virtio
             - name: cloudinit

--- a/kubernetes/applications/external-secrets/cluster-generator.yaml
+++ b/kubernetes/applications/external-secrets/cluster-generator.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: ClusterGenerator
+metadata:
+  name: password
+spec:
+  kind: Password
+  generator:
+    passwordSpec:
+      length: 42
+      digits: 0
+      symbols: 0
+      symbolCharacters: ""
+      allowRepeat: true

--- a/kubernetes/applications/external-secrets/cluster-secret-store.yaml
+++ b/kubernetes/applications/external-secrets/cluster-secret-store.yaml
@@ -3,7 +3,6 @@ apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: gcp-secret-manager
-  namespace: external-secrets
 spec:
   provider:
     gcpsm:
@@ -19,7 +18,6 @@ apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: 1password-sdk
-  namespace: external-secrets
 spec:
   provider:
     onepasswordSDK:

--- a/kubernetes/applications/external-secrets/kustomization.yaml
+++ b/kubernetes/applications/external-secrets/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: external-secrets
 resources:
   - namespace.yaml
   - cluster-secret-store.yaml
+  - cluster-generator.yaml
 helmCharts:
   - name: external-secrets
     repo: https://charts.external-secrets.io

--- a/kubernetes/applications/healthcheck/healthcheck.yaml
+++ b/kubernetes/applications/healthcheck/healthcheck.yaml
@@ -10,7 +10,7 @@ metadata:
   name: healthcheck
   namespace: healthcheck
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: healthcheck

--- a/kubernetes/applications/healthcheck/healthcheck.yaml
+++ b/kubernetes/applications/healthcheck/healthcheck.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: healthcheck
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/applications/healthcheck/namespace.yaml
+++ b/kubernetes/applications/healthcheck/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: healthcheck

--- a/kubernetes/applications/immich-mcp/immich-mcp.yaml
+++ b/kubernetes/applications/immich-mcp/immich-mcp.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: immich-mcp
----
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/applications/immich-mcp/namespace.yaml
+++ b/kubernetes/applications/immich-mcp/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: immich-mcp

--- a/kubernetes/applications/kube-prometheus-stack.yaml
+++ b/kubernetes/applications/kube-prometheus-stack.yaml
@@ -12,14 +12,8 @@ spec:
     targetRevision: 87.17.0
     helm:
       valuesObject:
-        # No receivers configured yet — enable once alert routing (e.g.
-        # Discord) is decided.
         alertmanager:
           enabled: false
-        # kubeadm binds scheduler/controller-manager/etcd metrics to
-        # localhost (etcd: 127.0.0.1:2381), so these targets are
-        # unscrapable without changing the static-pod manifests. Disabled
-        # to avoid permanently-firing "target down" noise.
         kubeControllerManager:
           enabled: false
         kubeScheduler:
@@ -28,10 +22,6 @@ spec:
           enabled: false
         kubeEtcd:
           enabled: false
-        # The VPS nodes are small and already busy being control planes;
-        # keep the heavy components on zen2. node-exporter still runs on
-        # every node (it must, to report per-node CPU), tolerating the
-        # control-plane taint on the VPSes.
         prometheusOperator:
           nodeSelector: &zen2
             kubernetes.io/hostname: zen2
@@ -54,10 +44,6 @@ spec:
             - operator: Exists
         grafana:
           nodeSelector: *zen2
-          # AuthN happens at the edge: grafana.toof.jp sits behind a
-          # Cloudflare Access application (terraform/access.tf). Grafana's
-          # own login (admin / prom-operator by default) is the second
-          # layer — change it after first login.
           ingress:
             enabled: true
             ingressClassName: cloudflare-tunnel
@@ -75,5 +61,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      # The stack's CRDs blow past the client-side-apply annotation limit.
       - ServerSideApply=true

--- a/kubernetes/applications/kubevirt/kubevirt-cr.yaml
+++ b/kubernetes/applications/kubevirt/kubevirt-cr.yaml
@@ -10,7 +10,6 @@ spec:
   customizeComponents: {}
   imagePullPolicy: IfNotPresent
   workloadUpdateStrategy: {}
-  # Only zen2 (bare metal) has /dev/kvm; the VPS nodes cannot run VMs
   workloads:
     nodePlacement:
       nodeSelector:

--- a/kubernetes/applications/longhorn.yaml
+++ b/kubernetes/applications/longhorn.yaml
@@ -5,37 +5,37 @@ metadata:
   name: longhorn
   namespace: argocd
 spec:
-  syncPolicy:
-    syncOptions:
-      - CreateNamespace=true
   project: default
-  sources:
-    - chart: longhorn
-      repoURL: https://charts.longhorn.io/
-      targetRevision: 1.12.0
-      helm:
-        valuesObject:
-          preUpgradeChecker:
-            jobEnabled: false
-          defaultSettings:
-            taintToleration: node-role.kubernetes.io/control-plane=:NoSchedule
-            defaultReplicaCount: 1
-          persistence:
-            defaultClassReplicaCount: 1
-          longhornManager:
-            tolerations: &controlPlaneToleration
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-                effect: NoSchedule
-          longhornDriver:
-            tolerations: *controlPlaneToleration
-          longhornUI:
-            tolerations: *controlPlaneToleration
-          ingress:
-            enabled: true
-            host: longhorn.toof.jp
-            ingressClassName: cloudflare-tunnel
-            path: /
+  source:
+    repoURL: https://charts.longhorn.io/
+    chart: longhorn
+    targetRevision: 1.12.0
+    helm:
+      valuesObject:
+        preUpgradeChecker:
+          jobEnabled: false
+        defaultSettings:
+          taintToleration: node-role.kubernetes.io/control-plane=:NoSchedule
+          defaultReplicaCount: 1
+        persistence:
+          defaultClassReplicaCount: 1
+        longhornManager:
+          tolerations: &controlPlaneToleration
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+        longhornDriver:
+          tolerations: *controlPlaneToleration
+        longhornUI:
+          tolerations: *controlPlaneToleration
+        ingress:
+          enabled: true
+          host: longhorn.toof.jp
+          ingressClassName: cloudflare-tunnel
+          path: /
   destination:
     server: https://kubernetes.default.svc
     namespace: longhorn-system
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/kubernetes/applications/mcp-gate/mcp-gate.yaml
+++ b/kubernetes/applications/mcp-gate/mcp-gate.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: mcp-gate
----
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/applications/mcp-gate/namespace.yaml
+++ b/kubernetes/applications/mcp-gate/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-gate

--- a/kubernetes/applications/metrics-server.yaml
+++ b/kubernetes/applications/metrics-server.yaml
@@ -13,8 +13,6 @@ spec:
     helm:
       valuesObject:
         args:
-          # kubeadm kubelets serve self-signed certs; without this the
-          # metrics-server can't scrape any node.
           - --kubelet-insecure-tls
   destination:
     server: https://kubernetes.default.svc

--- a/kubernetes/applications/npm-stats/cronjob.yaml
+++ b/kubernetes/applications/npm-stats/cronjob.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: npm-stats
----
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/kubernetes/applications/npm-stats/namespace.yaml
+++ b/kubernetes/applications/npm-stats/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: npm-stats

--- a/kubernetes/applications/obsidian-msp/namespace.yaml
+++ b/kubernetes/applications/obsidian-msp/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: obsidian-msp

--- a/kubernetes/applications/obsidian-msp/obsidian-msp.yaml
+++ b/kubernetes/applications/obsidian-msp/obsidian-msp.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: obsidian-msp
----
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/applications/obsidian/namespace.yaml
+++ b/kubernetes/applications/obsidian/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: obsidian

--- a/kubernetes/applications/obsidian/obsidian.yaml
+++ b/kubernetes/applications/obsidian/obsidian.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: obsidian
----
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/applications/shisha-log/namespace.yaml
+++ b/kubernetes/applications/shisha-log/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: shisha-log

--- a/kubernetes/applications/shisha-log/shisha-log.yaml
+++ b/kubernetes/applications/shisha-log/shisha-log.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: shisha-log
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
## 概要

マニフェスト全体レビューで見つかった指摘の修正です。

## 変更内容

- **ClusterGenerator `password` を external-secrets アプリへ移動** — cluster-scoped リソースが bbs 配下で定義され immich からも参照されており、bbs の prune に巻き込まれるリスクがあったため
- **Argo CD の install.yaml を v3.4.5 に固定** — `stable` ブランチ参照だとバージョンが動き、Renovate でも追跡できないため
- **healthcheck を replicas 1 に復帰** — Service / Ingress が生きたまま Deployment だけ 0 になっていた
- **Namespace を専用 namespace.yaml に統一** — ワークロードファイル埋め込みと専用ファイルの2流派が混在していたのを統一。cloudflare-external-secret には専用 Namespace を追加し、tunnel controller の CreateNamespace への順序依存を解消
- **記法の統一** — longhorn の `sources` → `source` とフィールド順、ApplicationSet elements のアルファベット順、同一 namespace 内 Service 参照の短縮形、ClusterSecretStore の無効な metadata.namespace 削除、dev-vm ghcr-auth への refreshPolicy 追加
- **マニフェスト内コメントの削除** — 方針(values-only)に合わせて削除し、理由はコミットメッセージ本文に退避

## 対応不要だったもの(レビュー時から main が先行)

- bbs の generator 名不一致 → 480e520 で修正済み
- bbs-mcp-server の `:latest` → digest ピン済み
- milktea 削除により ghcr-auth の重複は自然解消

## 見送り

- bbs postgres の PVC → volumeClaimTemplates 統一は、既存 PVC (`postgres-pvc`) のデータを引き継げず StatefulSet の再作成も必要なため見送り(やるならデータ移行手順とセットで別PR)

## 検証

- `prettier --check` 通過
- `kubectl kustomize` で argocd / kubevirt / cdi / external-secrets (--enable-helm) の build 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)