### PR TITLE
feat: HeadlampのトークンログインをCloudflare Access認証に置き換え

### DIFF
--- a/kubernetes/applications/headlamp.yaml
+++ b/kubernetes/applications/headlamp.yaml
@@ -6,20 +6,25 @@ metadata:
   namespace: argocd
 spec:
   project: default
-  source:
-    repoURL: https://kubernetes-sigs.github.io/headlamp/
-    chart: headlamp
-    targetRevision: "0.43.0"
-    helm:
-      valuesObject:
-        ingress:
-          enabled: true
-          ingressClassName: cloudflare-tunnel
-          hosts:
-            - host: headlamp.toof.jp
-              paths:
-                - path: /
-                  type: Prefix
+  sources:
+    - repoURL: https://github.com/toof-jp/infra
+      targetRevision: HEAD
+      path: kubernetes/applications/headlamp
+    - repoURL: https://kubernetes-sigs.github.io/headlamp/
+      chart: headlamp
+      targetRevision: "0.43.0"
+      helm:
+        valuesObject:
+          config:
+            unsafeUseServiceAccountToken: true
+          ingress:
+            enabled: true
+            ingressClassName: cloudflare-tunnel
+            hosts:
+              - host: headlamp.toof.jp
+                paths:
+                  - path: /
+                    type: Prefix
   destination:
     server: https://kubernetes.default.svc
     namespace: headlamp

--- a/kubernetes/applications/headlamp/networkpolicy.yaml
+++ b/kubernetes/applications/headlamp/networkpolicy.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare
+      ports:
+        - protocol: TCP
+          port: 4466


### PR DESCRIPTION
## 概要

headlamp.toof.jp は Cloudflare Access(GitHub IdP)で認証済みのため、Headlamp自体のトークン入力を廃止します。

## 変更内容

- `kubernetes/applications/headlamp.yaml`
  - chart 0.43.0 の `config.unsafeUseServiceAccountToken: true` を設定。認証プロキシ背後専用のオプションで、トークンプロンプトなしで全リクエストをPodのServiceAccount(cluster-admin)として扱う
  - NetworkPolicyを同梱するため、immichと同じmulti-source構成(ローカルディレクトリ + Helm chart)に変換
- `kubernetes/applications/headlamp/networkpolicy.yaml`(新規)
  - ingressを `cloudflare` namespaceからのport 4466のみに制限

## セキュリティ上の考慮

トークン認証を外すと、クラスタ内の任意PodからheadlampのServiceを直接叩くだけでcluster-admin相当のUIにアクセスできてしまうため、NetworkPolicyでトンネルコントローラ以外からの到達を遮断しています。外部からは引き続きCloudflare Access(`terraform/access.tf` の `zero_trust_apps`)の認証が必須です。

## 検証

- `kubectl apply --dry-run=server` で両ファイルともパス
- マージ後: headlamp.toof.jp にアクセスし、Accessログイン後にトークン入力なしでダッシュボードが表示されること、クラスタ内の別Podから `headlamp.headlamp.svc` への直接アクセスが拒否されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)