### PR TITLE
fix: immich postgresのPVCをPGDATAパスにマウント

### DIFF
--- a/kubernetes/applications/immich/postgres.yaml
+++ b/kubernetes/applications/immich/postgres.yaml
@@ -47,7 +47,7 @@ spec:
                 name: postgres-secret
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/postgresql
+              mountPath: /var/lib/postgresql/data
             - name: dshm
               mountPath: /dev/shm
       volumes:


### PR DESCRIPTION
## 概要

immich の postgres StatefulSet で、PVC のマウント先を `/var/lib/postgresql` から `/var/lib/postgresql/data`(PGDATA)に修正します。

## 背景(photo.toof.jp が 500 になっていた原因)

- PVC は `/var/lib/postgresql` にマウントされていたが、postgres イメージの PGDATA デフォルトは `/var/lib/postgresql/data`
- そのパスはイメージの `VOLUME` 宣言により containerd がノードローカルの一時領域(image volume)としてバインドマウントするため、**DB の書き込みは一度も PVC に載っていなかった**(PVC 直下は `lost+found` のみ、Longhorn 実使用 ~239MB のファイルシステムオーバーヘッドだけ)
- #131 の postgres イメージ更新で Pod が再作成された際、一時領域が消えて initdb が走り、DB が空に。`immich-server` は起動済みのままなのでマイグレーションが走らず、`relation "system_metadata" does not exist` で API が 500 を返していた

## 影響

- 7/14〜7/17 の DB データ(ユーザー・アルバム・メタデータ)は旧コンテナ削除時に失われており復旧不可
- アップロード済みアセット自体は `immich-library` PVC(実使用 ~1.5GB)に残存

## 適用後の手順

1. マージ → ArgoCD が postgres Pod を再作成(PVC 上に initdb される)
2. `kubectl rollout restart -n immich deploy/immich-server` でマイグレーション実行
3. 管理者アカウントを再作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)