### PR TITLE
fix: immich postgresのデータをsubPathでマウント

### DIFF
--- a/kubernetes/applications/immich/postgres.yaml
+++ b/kubernetes/applications/immich/postgres.yaml
@@ -48,6 +48,7 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
+              subPath: data
             - name: dshm
               mountPath: /dev/shm
       volumes:


### PR DESCRIPTION
## 概要

#144 の続きです。PVC のルートは ext4 の `lost+found` があるため initdb が「ディレクトリが空でない」と拒否して postgres-0 が Error になっています。`subPath: data` を追加して PVC 内の `data/` サブディレクトリを PGDATA にマウントすることで、初回起動時に空ディレクトリとなり initdb が通ります。

## 適用後

postgres-0 が正常起動して PVC 上に initdb されるので、その後 `immich-server` を restart してマイグレーションを実行します(こちらで実施します)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)