### PR TITLE
argocd-diff-preview を導入

### DIFF
--- a/.github/workflows/argocd-diff-preview.yaml
+++ b/.github/workflows/argocd-diff-preview.yaml
@@ -1,0 +1,46 @@
+name: argocd-diff-preview
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "kubernetes/**"
+      - ".github/workflows/argocd-diff-preview.yaml"
+
+jobs:
+  diff-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: pull-request
+
+      - name: Checkout main branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          path: main
+
+      - name: Generate diff
+        run: |
+          docker run \
+            --network=host \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v $(pwd)/main:/base-branch \
+            -v $(pwd)/pull-request:/target-branch \
+            -v $(pwd)/output:/output \
+            -e TARGET_BRANCH=refs/pull/${{ github.event.number }}/merge \
+            -e REPO=${{ github.repository }} \
+            dagandersen/argocd-diff-preview:v0.2.11
+
+      - name: Post diff as comment
+        run: |
+          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md --edit-last || \
+          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/argocd-diff-preview.yaml
+++ b/.github/workflows/argocd-diff-preview.yaml
@@ -26,6 +26,14 @@ jobs:
           ref: main
           path: main
 
+      - name: Set Argo CD custom values
+        run: |
+          cat > values.yaml << "EOF"
+          configs:
+            cm:
+              kustomize.buildOptions: --enable-helm
+          EOF
+
       - name: Generate diff
         run: |
           docker run \
@@ -34,6 +42,7 @@ jobs:
             -v $(pwd)/main:/base-branch \
             -v $(pwd)/pull-request:/target-branch \
             -v $(pwd)/output:/output \
+            -v $(pwd)/values.yaml:/argocd-config/values.yaml \
             -e TARGET_BRANCH=refs/pull/${{ github.event.number }}/merge \
             -e REPO=${{ github.repository }} \
             dagandersen/argocd-diff-preview:v0.2.11


### PR DESCRIPTION
## 概要

PR ごとに Argo CD がレンダリングするマニフェストの差分をコメントとして投稿する [argocd-diff-preview](https://github.com/dag-andersen/argocd-diff-preview) のワークフローを追加します。

## 動作

- `kubernetes/**` に変更がある PR で起動
- CI 内に使い捨ての kind クラスタを立てて Argo CD をインストールし、base/target 両ブランチをレンダリングして比較
- 差分を `gh pr comment --edit-last` で PR コメントとして投稿(既存コメントがあれば更新)

## セキュリティ

- 実クラスタへの認証情報は不要(必要な権限は `contents: read` と `pull-requests: write` のみ)
- 差分は git の内容のみから生成されるため、External Secrets 経由の実際の Secret 値が混入する経路は存在しない

## 備考

- app-of-apps の子 Application と ApplicationSet(list generator)はすべてプレーン YAML のため追加設定なしで動作
- Renovate による Helm チャート更新 PR でも実際の変更内容が可視化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)