### PR TITLE
CI にマニフェスト検証と terraform validate を追加

### DIFF
--- a/.github/workflows/terraform-fmt.yaml
+++ b/.github/workflows/terraform-fmt.yaml
@@ -22,3 +22,11 @@ jobs:
 
       - name: Check formatting
         run: terraform fmt -check -diff -recursive
+
+      - name: Init
+        run: terraform init -backend=false -input=false
+        working-directory: terraform
+
+      - name: Validate
+        run: terraform validate
+        working-directory: terraform

--- a/.github/workflows/validate-kubernetes.yaml
+++ b/.github/workflows/validate-kubernetes.yaml
@@ -1,0 +1,56 @@
+name: validate-kubernetes
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "kubernetes/**"
+      - ".github/workflows/validate-kubernetes.yaml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "kubernetes/**"
+      - ".github/workflows/validate-kubernetes.yaml"
+
+env:
+  KUSTOMIZE_VERSION: 5.7.1
+  KUBECONFORM_VERSION: 0.7.0
+  HELM_VERSION: 3.19.0
+
+jobs:
+  kubeconform:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install tools
+        run: |
+          mkdir -p "$RUNNER_TEMP/bin"
+          curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" | tar xz -C "$RUNNER_TEMP/bin" kustomize
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | tar xz -C "$RUNNER_TEMP/bin" kubeconform
+          curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | tar xz -C "$RUNNER_TEMP" linux-amd64/helm
+          mv "$RUNNER_TEMP/linux-amd64/helm" "$RUNNER_TEMP/bin/helm"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Build kustomizations and validate
+        run: |
+          set -euo pipefail
+          schema_args=(
+            -strict
+            -ignore-missing-schemas
+            -schema-location default
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}{{.KindSuffix}}.json'
+          )
+          exclude_args=()
+          while IFS= read -r dir; do
+            echo "==> kustomize build $dir"
+            kustomize build --enable-helm "$dir" | kubeconform "${schema_args[@]}" -summary -
+            exclude_args+=(-not -path "$dir/*")
+          done < <(find kubernetes -name kustomization.yaml -exec dirname {} \; | sort)
+          echo "==> plain manifests"
+          find kubernetes -name '*.yaml' "${exclude_args[@]}" -print0 | xargs -0 kubeconform "${schema_args[@]}" -summary


### PR DESCRIPTION
## 概要

既存の CI は整形チェック(prettier / terraform fmt)のみだったため、マニフェストと Terraform 設定の中身を検証するチェックを追加します。

## 変更内容

### validate-kubernetes ワークフロー(新規)

- `kustomization.yaml` があるディレクトリすべてを `kustomize build --enable-helm` でビルドし、壊れた kustomization をマージ前に検出
- ビルド結果と素のマニフェスト(ArgoCD Application など)を kubeconform でスキーマ検証
  - CRD は datree の CRDs-catalog を参照し、カタログにないものは `-ignore-missing-schemas` でスキップ
- kustomize / kubeconform / helm はバージョン固定でバイナリを直接取得(kustomize は helm 4 と非互換のため helm 3 を明示)

### terraform fmt ワークフロー

- `terraform init -backend=false` + `terraform validate` を追加し、HCP Terraform の plan を待たずに構文・参照エラーを PR 上で検出

## 動作確認

- ローカルで全 kustomization のビルドと kubeconform 検証を実行し、304 リソースすべて Valid / Invalid 0 を確認
- `terraform validate` がローカルで成功することを確認
- `bun run format:check` が新規ワークフローを含めて通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)