### PR TITLE
docs: READMEを現在の構成に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ flowchart LR
             sakuravps["sakura-vps<br/>NixOS<br/>4 CPU / 4 GiB<br/>control-plane (tainted)"]
         end
         subgraph vultrcloud["Vultr"]
-            vultrvps["vultr-vps<br/>NixOS<br/>1 CPU / 2 GiB<br/>control-plane (tainted)"]
+            vultrvps["vultr-vps<br/>NixOS<br/>2 CPU / 4 GiB<br/>control-plane (tainted)"]
         end
     end
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Personal infrastructure monorepo: Kubernetes manifests synced by Argo CD and Ter
 ├── kubernetes/
 │   ├── app-of-apps.yaml      # Argo CD root Application
 │   └── applications/         # ApplicationSet + per-app manifests
-├── terraform/                # Cloudflare / GCP / AWS / Vultr / Discord resources
+├── terraform/                # Cloudflare / GCP / AWS / Vultr / Auth0 / Discord resources
 └── docs/                     # Operational notes
 ```
 
@@ -31,15 +31,16 @@ flowchart TB
         argocd["Argo CD"]
         appofapps["app-of-apps"]
         appset["ApplicationSet"]
-        apps["Applications<br/>archiveteam-warrior, bbs, blues,<br/>healthcheck, monitoring,<br/>npm-stats, obsidian-msp, shisha-log, ..."]
-        platform["Platform<br/>longhorn, external-secrets,<br/>cloudflare-tunnel-ingress-controller,<br/>kubernetes-dashboard"]
+        apps["Applications<br/>archiveteam-warrior, argocd, bbs, blues,<br/>dev-vm, healthcheck, kubevirt, mcp-gate,<br/>milktea, monitoring, npm-stats, obsidian,<br/>obsidian-msp, shisha-log, ..."]
+        platform["Platform (Helm)<br/>longhorn, external-secrets,<br/>cloudflare-tunnel-ingress-controller,<br/>kube-prometheus-stack, metrics-server,<br/>headlamp, immich"]
     end
 
     subgraph providers["Cloud providers"]
-        cloudflare["Cloudflare<br/>DNS / Tunnel"]
+        cloudflare["Cloudflare<br/>DNS / Tunnel / Zero Trust Access"]
         gcp["Google Cloud<br/>Secret Manager / Monitoring /<br/>Cloud Functions"]
         aws["AWS<br/>S3 (Terraform remote state)"]
         vultr["Vultr<br/>vultr-vps instance"]
+        auth0["Auth0<br/>MCP OAuth clients"]
         discord["Discord<br/>alert webhook"]
     end
 


### PR DESCRIPTION
## 概要

README のアプリケーション一覧・プロバイダ一覧を現在のリポジトリ構成に合わせて更新しました。

## 変更内容

- ApplicationSet 管理のアプリ一覧に `argocd` / `dev-vm` / `kubevirt` / `mcp-gate` / `obsidian` を追加
- プラットフォーム層を実際の Helm ベース Application(`kube-prometheus-stack` / `metrics-server` / `headlamp` / `immich`)に更新し、廃止済みの `kubernetes-dashboard` を削除
- Terraform プロバイダに Auth0(MCP 用 OAuth クライアント)を追加、Cloudflare に Zero Trust Access を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)