### PR TITLE
feat: OpenClaw によるクラスタ・Prometheus 監視と Discord 通知を追加

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -40,6 +40,8 @@ spec:
             namespace: obsidian
           - name: obsidian-msp
             namespace: obsidian-msp
+          - name: openclaw
+            namespace: openclaw
           - name: shisha-log
             namespace: shisha-log
   template:

--- a/kubernetes/applications/openclaw/README.md
+++ b/kubernetes/applications/openclaw/README.md
@@ -6,12 +6,24 @@
 - Discord: bot connection via `DISCORD_BOT_TOKEN`
 - Cluster access: read-only RBAC (`view` + cluster-scoped read) with `kubectl` installed by an init container
 - Prometheus: `http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090`
+- Model: Claude on Vertex AI (`anthropic-vertex/claude-sonnet-4-6`) via the `openclaw-vertex-sa` service account
+
+## Vertex AI Provider
+
+The agent talks to Claude through Google Vertex AI instead of the Anthropic API. Terraform (`terraform/service_account.tf`, `terraform/api.tf`) provisions everything: enables `aiplatform.googleapis.com`, creates the `openclaw-vertex-sa` service account with `roles/aiplatform.user`, and stores its key in GCP Secret Manager as `openclaw-vertex-sa-key`. The Deployment mounts the key and sets `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION` for ADC.
+
+The official Docker image does not bundle the Vertex provider's dependencies, so install the plugin once after the first deploy (it persists on the state PVC):
+
+```sh
+kubectl -n openclaw exec deploy/openclaw -- \
+  node /app/openclaw.mjs plugin add @openclaw/anthropic-vertex-provider
+kubectl -n openclaw rollout restart deploy/openclaw
+```
 
 ## Secret Values
 
-Create these secrets in GCP Secret Manager (project `toof-infra`):
+Create this secret in GCP Secret Manager (project `toof-infra`):
 
-- `openclaw-anthropic-api-key`: Anthropic API key used by the agent
 - `openclaw-discord-bot-token`: Discord bot token (see below)
 
 The gateway auth token (`OPENCLAW_GATEWAY_TOKEN`) is generated in-cluster by the `password` ClusterGenerator. Read it with:

--- a/kubernetes/applications/openclaw/README.md
+++ b/kubernetes/applications/openclaw/README.md
@@ -1,0 +1,73 @@
+# OpenClaw
+
+[OpenClaw](https://openclaw.ai) gateway running in-cluster as a monitoring agent. It watches the Kubernetes cluster and Prometheus, and reports to Discord.
+
+- Control UI: `https://openclaw.toof.jp` (token auth)
+- Discord: bot connection via `DISCORD_BOT_TOKEN`
+- Cluster access: read-only RBAC (`view` + cluster-scoped read) with `kubectl` installed by an init container
+- Prometheus: `http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090`
+
+## Secret Values
+
+Create these secrets in GCP Secret Manager (project `toof-infra`):
+
+- `openclaw-anthropic-api-key`: Anthropic API key used by the agent
+- `openclaw-discord-bot-token`: Discord bot token (see below)
+
+The gateway auth token (`OPENCLAW_GATEWAY_TOKEN`) is generated in-cluster by the `password` ClusterGenerator. Read it with:
+
+```sh
+kubectl -n openclaw get secret openclaw-gateway-token-secret \
+  -o jsonpath='{.data.OPENCLAW_GATEWAY_TOKEN}' | base64 -d
+```
+
+Paste it into the Control UI at `https://openclaw.toof.jp` (Settings -> Token).
+
+## Discord Bot
+
+1. Create an application at <https://discord.com/developers/applications> and add a Bot.
+2. Enable the **Message Content Intent** under Privileged Gateway Intents.
+3. Copy the bot token into the `openclaw-discord-bot-token` GCP secret.
+4. Invite the bot to the server via OAuth2 URL Generator (`bot` scope; Send Messages, Read Message History, Create Public Threads permissions).
+5. DM the bot once and approve the pairing code:
+
+   ```sh
+   kubectl -n openclaw exec deploy/openclaw -- \
+     node /app/openclaw.mjs pairing approve discord <CODE>
+   ```
+
+## Monitoring Cron Jobs
+
+Cron jobs are stored in the gateway state (SQLite on the `openclaw-state` PVC), so they are created once via the CLI rather than declared in manifests:
+
+```sh
+kubectl -n openclaw exec deploy/openclaw -- \
+  node /app/openclaw.mjs cron create "*/30 * * * *" \
+  "Check cluster health. Use kubectl to look for NotReady nodes, pods that are not Running/Succeeded, and recent Warning events. Query Prometheus at http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090 for firing alerts and for node CPU, memory, and disk usage above 90%. Only send a report if something needs attention; stay silent otherwise." \
+  --name "cluster-health" \
+  --session isolated \
+  --announce \
+  --channel discord \
+  --to "channel:<DISCORD_CHANNEL_ID>"
+```
+
+A daily summary variant:
+
+```sh
+kubectl -n openclaw exec deploy/openclaw -- \
+  node /app/openclaw.mjs cron create "0 9 * * *" \
+  "Post a short daily cluster summary: node status, workload health by namespace, Longhorn volume state, Argo CD application sync status, and any Prometheus alerts that fired in the last 24h." \
+  --name "daily-summary" \
+  --session isolated \
+  --announce \
+  --channel discord \
+  --to "channel:<DISCORD_CHANNEL_ID>"
+```
+
+List and remove jobs with `cron list` / `cron delete <id>`.
+
+## Notes
+
+- The pod runs with a read-only ServiceAccount; the agent can inspect but not mutate the cluster.
+- `openclaw.json` is mounted read-only from the `openclaw-config` ConfigMap (`OPENCLAW_CONFIG_PATH`); edit it via Git, not the Control UI.
+- Everything else (sessions, cron store, workspace, auth profiles) persists on the `openclaw-state` PVC.

--- a/kubernetes/applications/openclaw/configmap.yaml
+++ b/kubernetes/applications/openclaw/configmap.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+  namespace: openclaw
+data:
+  openclaw.json: |
+    {
+      "gateway": {
+        "bind": "lan",
+        "port": 18789,
+        "auth": {
+          "token": "${OPENCLAW_GATEWAY_TOKEN}"
+        }
+      },
+      "channels": {
+        "discord": {
+          "enabled": true,
+          "token": {
+            "source": "env",
+            "provider": "default",
+            "id": "DISCORD_BOT_TOKEN"
+          }
+        }
+      },
+      "agents": {
+        "defaults": {
+          "model": {
+            "primary": "anthropic/claude-sonnet-4-6"
+          }
+        }
+      },
+      "cron": {
+        "enabled": true
+      }
+    }

--- a/kubernetes/applications/openclaw/configmap.yaml
+++ b/kubernetes/applications/openclaw/configmap.yaml
@@ -27,7 +27,7 @@ data:
       "agents": {
         "defaults": {
           "model": {
-            "primary": "anthropic/claude-sonnet-4-6"
+            "primary": "anthropic-vertex/claude-sonnet-4-6"
           }
         }
       },

--- a/kubernetes/applications/openclaw/external-secret.yaml
+++ b/kubernetes/applications/openclaw/external-secret.yaml
@@ -12,12 +12,27 @@ spec:
   target:
     name: openclaw-secret
   data:
-    - secretKey: ANTHROPIC_API_KEY
-      remoteRef:
-        key: openclaw-anthropic-api-key
     - secretKey: DISCORD_BOT_TOKEN
       remoteRef:
         key: openclaw-discord-bot-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openclaw-vertex-sa-key-external-secret
+  namespace: openclaw
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: openclaw-vertex-sa-key
+  data:
+    - secretKey: GOOGLE_CREDENTIALS_JSON
+      remoteRef:
+        key: openclaw-vertex-sa-key
+        decodingStrategy: Base64
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/kubernetes/applications/openclaw/external-secret.yaml
+++ b/kubernetes/applications/openclaw/external-secret.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openclaw-external-secret
+  namespace: openclaw
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: openclaw-secret
+  data:
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef:
+        key: openclaw-anthropic-api-key
+    - secretKey: DISCORD_BOT_TOKEN
+      remoteRef:
+        key: openclaw-discord-bot-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openclaw-gateway-token-external-secret
+  namespace: openclaw
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: openclaw-gateway-token-secret
+    template:
+      type: Opaque
+      data:
+        OPENCLAW_GATEWAY_TOKEN: "{{ .password }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: ClusterGenerator
+          name: password

--- a/kubernetes/applications/openclaw/namespace.yaml
+++ b/kubernetes/applications/openclaw/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openclaw

--- a/kubernetes/applications/openclaw/openclaw.yaml
+++ b/kubernetes/applications/openclaw/openclaw.yaml
@@ -56,6 +56,12 @@ spec:
               value: /etc/openclaw/openclaw.json
             - name: PATH
               value: /tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secrets/google/key.json
+            - name: GOOGLE_CLOUD_PROJECT
+              value: toof-infra
+            - name: GOOGLE_CLOUD_LOCATION
+              value: global
           envFrom:
             - secretRef:
                 name: openclaw-secret
@@ -81,6 +87,9 @@ spec:
             - name: config
               mountPath: /etc/openclaw
               readOnly: true
+            - name: vertex-sa-key
+              mountPath: /var/secrets/google
+              readOnly: true
             - name: tools
               mountPath: /tools
       volumes:
@@ -90,6 +99,12 @@ spec:
         - name: config
           configMap:
             name: openclaw-config
+        - name: vertex-sa-key
+          secret:
+            secretName: openclaw-vertex-sa-key
+            items:
+              - key: GOOGLE_CREDENTIALS_JSON
+                path: key.json
         - name: tools
           emptyDir: {}
 ---

--- a/kubernetes/applications/openclaw/openclaw.yaml
+++ b/kubernetes/applications/openclaw/openclaw.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-state
+  namespace: openclaw
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openclaw
+  template:
+    metadata:
+      labels:
+        app: openclaw
+    spec:
+      serviceAccountName: openclaw
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+        - name: install-kubectl
+          image: curlimages/curl:8.14.1
+          command:
+            - sh
+            - -c
+            - >-
+              VERSION=$(curl -fsSL https://dl.k8s.io/release/stable-1.36.txt) &&
+              curl -fsSL "https://dl.k8s.io/release/${VERSION}/bin/linux/amd64/kubectl"
+              -o /tools/kubectl &&
+              chmod 0755 /tools/kubectl
+          volumeMounts:
+            - name: tools
+              mountPath: /tools
+      containers:
+        - name: openclaw
+          image: ghcr.io/openclaw/openclaw:2026.7.1
+          ports:
+            - name: http
+              containerPort: 18789
+          env:
+            - name: OPENCLAW_CONFIG_PATH
+              value: /etc/openclaw/openclaw.json
+            - name: PATH
+              value: /tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          envFrom:
+            - secretRef:
+                name: openclaw-secret
+            - secretRef:
+                name: openclaw-gateway-token-secret
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 60
+          volumeMounts:
+            - name: state
+              mountPath: /home/node/.openclaw
+              subPath: openclaw
+            - name: state
+              mountPath: /home/node/.config/openclaw
+              subPath: config
+            - name: config
+              mountPath: /etc/openclaw
+              readOnly: true
+            - name: tools
+              mountPath: /tools
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: openclaw-state
+        - name: config
+          configMap:
+            name: openclaw-config
+        - name: tools
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  selector:
+    app: openclaw
+  ports:
+    - name: http
+      port: 18789
+      targetPort: 18789
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: openclaw.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: openclaw
+                port:
+                  number: 18789

--- a/kubernetes/applications/openclaw/rbac.yaml
+++ b/kubernetes/applications/openclaw/rbac.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openclaw
+  namespace: openclaw
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openclaw-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openclaw-cluster-read
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "namespaces", "persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications", "applicationsets", "appprojects"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["longhorn.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kubevirt.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openclaw-cluster-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openclaw-cluster-read
+subjects:
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -14,6 +14,7 @@ locals {
     "run.googleapis.com",
     "eventarc.googleapis.com",
     "secretmanager.googleapis.com",
+    "aiplatform.googleapis.com",
   ]
 }
 

--- a/terraform/service_account.tf
+++ b/terraform/service_account.tf
@@ -77,3 +77,32 @@ resource "google_secret_manager_secret_version" "terraform_sa_secret_ver" {
   secret      = google_secret_manager_secret.terraform_sa_secret.id
   secret_data = google_service_account_key.terraform_sa_key.private_key
 }
+
+resource "google_service_account" "openclaw_vertex_sa" {
+  account_id   = "openclaw-vertex-sa"
+  display_name = "Service account for OpenClaw Vertex AI"
+  depends_on   = [google_project_service.enabled["iam.googleapis.com"]]
+}
+
+resource "google_project_iam_member" "openclaw_vertex_sa" {
+  project = google_project.toof_infra.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.openclaw_vertex_sa.email}"
+}
+
+resource "google_service_account_key" "openclaw_vertex_sa_key" {
+  service_account_id = google_service_account.openclaw_vertex_sa.name
+}
+
+resource "google_secret_manager_secret" "openclaw_vertex_sa_secret" {
+  secret_id = "openclaw-vertex-sa-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "openclaw_vertex_sa_secret_ver" {
+  secret      = google_secret_manager_secret.openclaw_vertex_sa_secret.id
+  secret_data = google_service_account_key.openclaw_vertex_sa_key.private_key
+}


### PR DESCRIPTION
## 概要

[OpenClaw](https://openclaw.ai) をクラスタ内にデプロイし、Kubernetes と Prometheus を監視して Discord に通知するエージェントを追加します。Claude へのアクセスは Anthropic API キーではなく **Google Vertex AI(ADC 認証)** を使用します。

## 構成

- `ghcr.io/openclaw/openclaw:2026.7.1` を `openclaw` namespace に Deployment としてデプロイ(state は Longhorn PVC 5Gi、`Recreate` 戦略)
- **モデルアクセス(Vertex AI)**
  - Terraform で `aiplatform.googleapis.com` を有効化し、`openclaw-vertex-sa`(`roles/aiplatform.user`)を作成、キーを Secret Manager `openclaw-vertex-sa-key` に格納
  - ExternalSecret がキーを Pod にマウントし、`GOOGLE_APPLICATION_CREDENTIALS` / `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION=global` で ADC 認証
  - モデルは `anthropic-vertex/claude-sonnet-4-6`(公式 `@openclaw/anthropic-vertex-provider` プラグイン経由)
- **監視能力**
  - 読み取り専用 RBAC(組み込み `view` + nodes / metrics / Argo CD / Longhorn / KubeVirt / monitoring CRD の cluster-scoped read)
  - initContainer が `kubectl`(stable-1.36)を導入し、エージェントから利用可能
  - Prometheus は `http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090` へクラスタ内アクセス
- **Discord 通知**: bot トークンを ExternalSecret(GCP Secret Manager)で注入し、OpenClaw の cron 機能で定期チェック結果をチャンネルに配信(cron 作成コマンドは README 参照)
- **設定は GitOps 管理**: `openclaw.json` は ConfigMap を read-only マウントし `OPENCLAW_CONFIG_PATH` で指定。gateway トークンは `password` ClusterGenerator でクラスタ内生成
- Control UI は `openclaw.toof.jp`(Cloudflare Tunnel Ingress、トークン認証)

## デプロイ後の手動作業(README に記載)

1. GCP Secret Manager に `openclaw-discord-bot-token` を作成(Vertex SA キーは Terraform が自動生成)
2. Discord Developer Portal で bot を作成(Message Content Intent 有効化)しサーバーへ招待
3. `kubectl exec` で `@openclaw/anthropic-vertex-provider` プラグインをインストール(公式イメージに依存が同梱されないため。PVC に永続化)
4. `kubectl exec` で監視用 cron ジョブを登録(cron 定義は SQLite 保存のため宣言的管理外)

## 検証

- `prettier --check` / `terraform fmt -check` パス
- CI と同一オプションの `kubeconform -strict` で全マニフェスト Valid(13 resources / Invalid 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
