### PR TITLE
fix: OpenClaw の設定を書き込み可能な state volume に配置

### DIFF
--- a/kubernetes/applications/openclaw/README.md
+++ b/kubernetes/applications/openclaw/README.md
@@ -81,5 +81,5 @@ List and remove jobs with `cron list` / `cron delete <id>`.
 ## Notes
 
 - The pod runs with a read-only ServiceAccount; the agent can inspect but not mutate the cluster.
-- `openclaw.json` is mounted read-only from the `openclaw-config` ConfigMap (`OPENCLAW_CONFIG_PATH`); edit it via Git, not the Control UI.
+- `openclaw.json` is copied from the `openclaw-config` ConfigMap to the state PVC by an init container on every pod start (OpenClaw needs the config directory writable); edit it via Git, then `kubectl -n openclaw rollout restart deploy/openclaw` to apply.
 - Everything else (sessions, cron store, workspace, auth profiles) persists on the `openclaw-state` PVC.

--- a/kubernetes/applications/openclaw/openclaw.yaml
+++ b/kubernetes/applications/openclaw/openclaw.yaml
@@ -45,6 +45,21 @@ spec:
           volumeMounts:
             - name: tools
               mountPath: /tools
+        - name: copy-config
+          image: curlimages/curl:8.14.1
+          command:
+            - sh
+            - -c
+            - >-
+              cp /config-src/openclaw.json /state/openclaw.json &&
+              chmod 664 /state/openclaw.json
+          volumeMounts:
+            - name: config
+              mountPath: /config-src
+              readOnly: true
+            - name: state
+              mountPath: /state
+              subPath: openclaw
       containers:
         - name: openclaw
           image: ghcr.io/openclaw/openclaw:2026.7.1
@@ -52,8 +67,6 @@ spec:
             - name: http
               containerPort: 18789
           env:
-            - name: OPENCLAW_CONFIG_PATH
-              value: /etc/openclaw/openclaw.json
             - name: PATH
               value: /tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -84,9 +97,6 @@ spec:
             - name: state
               mountPath: /home/node/.config/openclaw
               subPath: config
-            - name: config
-              mountPath: /etc/openclaw
-              readOnly: true
             - name: vertex-sa-key
               mountPath: /var/secrets/google
               readOnly: true


### PR DESCRIPTION
## 概要

PR #149 でデプロイした OpenClaw が起動時にクラッシュする問題の修正です。

## 問題

`OPENCLAW_CONFIG_PATH` で read-only の ConfigMap マウント(`/etc/openclaw/openclaw.json`)を指定していましたが、OpenClaw はプラグイン・npm の作業ディレクトリを**設定ファイルのあるディレクトリ配下**に作成するため、起動時に失敗していました:

```
[openclaw] Reason: ENOENT: no such file or directory, mkdir '/etc/openclaw/npm'
```

## 修正

- `OPENCLAW_CONFIG_PATH` と read-only マウントを廃止し、デフォルトパス(state PVC 上の `~/.openclaw/openclaw.json`)を使用
- initContainer `copy-config` が Pod 起動ごとに ConfigMap から設定をコピー(Git が引き続き source of truth、変更反映は `rollout restart`)

## 検証

- `prettier --check` / `kubeconform -strict` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
