### PR TITLE
immich-mcpをDOWNLOAD_MODE=base64対応のパッチ版イメージに切り替え

### DIFF
--- a/kubernetes/applications/immich-mcp/ghcr-auth.yaml
+++ b/kubernetes/applications/immich-mcp/ghcr-auth.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: immich-mcp
+imagePullSecrets:
+  - name: ghcr-auth
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ghcr-auth
+  namespace: immich-mcp
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: ghcr-auth
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "ghcr.io": {
+                "username": "toof-jp",
+                "password": "{{ .pat }}",
+                "email": "unused@example.com",
+                "auth": "{{ printf "%s:%s" "toof-jp" .pat | b64enc }}"
+              }
+            }
+          }
+  data:
+    - secretKey: pat
+      remoteRef:
+        key: ghcr-pat

--- a/kubernetes/applications/immich-mcp/immich-mcp.yaml
+++ b/kubernetes/applications/immich-mcp/immich-mcp.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
         - name: immich-mcp
-          image: ghcr.io/barryw/immichmcp:v3.1.5
+          image: ghcr.io/toof-jp/immichmcp:v3.1.5-base64.1
           ports:
             - name: http
               containerPort: 5000


### PR DESCRIPTION
## 概要

Claudeコネクタから写真をその場で表示できるようにするため、immich-mcpをパッチ版イメージ `ghcr.io/toof-jp/immichmcp:v3.1.5-base64.1` に切り替えます。

## 背景

- 上流ImmichMCP v3.1.5では `DOWNLOAD_MODE` がREADMEに記載され環境変数として読み込まれるものの、実装がどこからも参照されておらず未実装(常にURLを返す)
- 返るURLはクラスタ内部アドレス(`immich-server.immich.svc.cluster.local`)のため、MCPクライアント(Claude)から画像を表示する手段がなかった
- パッチはfork([toof-jp/ImmichMCP feat/download-mode-base64](https://github.com/toof-jp/ImmichMCP/tree/feat/download-mode-base64))で実装。`DOWNLOAD_MODE=base64` のとき、サムネイルはMCPのImageContentBlockとしてインライン返却される(上流へのPRは動作確認後に提出予定)

## 変更内容

- `immich-mcp.yaml`: イメージを `ghcr.io/barryw/immichmcp:v3.1.5` → `ghcr.io/toof-jp/immichmcp:v3.1.5-base64.1` に変更
- `ghcr-auth.yaml`: forkイメージのパッケージがprivateのため、dev-vmと同じパターン(ExternalSecret + ServiceAccountのimagePullSecrets、既存の `ghcr-pat` シークレットを使用)でpull認証を追加

## 検証済み

- Dockerコンテナでビルド(警告0)・ユニットテスト80件全パス
- パッチ版イメージをローカルで起動し、photo.toof.jp経由の実Immichに対してMCPプロトコルで `immich_assets_download_thumbnail` を呼び出し、正しいJPEG(1440x2560)がImageContentBlockで返ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)