### PR TITLE
fix: OpenClaw ゲートウェイのヘッドレス起動設定を完成

### DIFF
--- a/kubernetes/applications/openclaw/README.md
+++ b/kubernetes/applications/openclaw/README.md
@@ -12,13 +12,7 @@
 
 The agent talks to Claude through Google Vertex AI instead of the Anthropic API. Terraform (`terraform/service_account.tf`, `terraform/api.tf`) provisions everything: enables `aiplatform.googleapis.com`, creates the `openclaw-vertex-sa` service account with `roles/aiplatform.user`, and stores its key in GCP Secret Manager as `openclaw-vertex-sa-key`. The Deployment mounts the key and sets `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION` for ADC.
 
-The official Docker image does not bundle the Vertex provider's dependencies, so install the plugin once after the first deploy (it persists on the state PVC):
-
-```sh
-kubectl -n openclaw exec deploy/openclaw -- \
-  node /app/openclaw.mjs plugin add @openclaw/anthropic-vertex-provider
-kubectl -n openclaw rollout restart deploy/openclaw
-```
+The official Docker image does not bundle the Vertex provider, but no manual install is needed: the plugins are declared in `openclaw.json` (`plugins.entries`), and the gateway's startup doctor auto-installs `@openclaw/anthropic-vertex-provider` and `@openclaw/discord` from npm onto the state PVC on first start.
 
 ## Secret Values
 

--- a/kubernetes/applications/openclaw/configmap.yaml
+++ b/kubernetes/applications/openclaw/configmap.yaml
@@ -8,10 +8,21 @@ data:
   openclaw.json: |
     {
       "gateway": {
+        "mode": "local",
         "bind": "lan",
         "port": 18789,
-        "auth": {
-          "token": "${OPENCLAW_GATEWAY_TOKEN}"
+        "controlUi": {
+          "allowedOrigins": ["https://openclaw.toof.jp"]
+        }
+      },
+      "plugins": {
+        "entries": {
+          "discord": {
+            "enabled": true
+          },
+          "anthropic-vertex": {
+            "enabled": true
+          }
         }
       },
       "channels": {


### PR DESCRIPTION
## 概要

PR #151 の続きです。OpenClaw ゲートウェイがヘッドレス起動できるよう設定を完成させます。**今回はマージ前に、この設定そのままでイメージをローカル Docker 起動して検証済みです**(gateway ready、警告なし、healthz 200)。

## 変更内容

- `gateway.mode: "local"` を追加 — これがないと起動を拒否します(`Gateway start blocked: existing config is missing gateway.mode`)
- `gateway.auth` ブロックを削除 — `${OPENCLAW_GATEWAY_TOKEN}` の env 置換は非対応で、トークンは env 変数から直接読まれるため不要
- `plugins.entries` で `discord` / `anthropic-vertex` を明示的に有効化 — 検証で「external plugin installed without explicit trust」警告が出たため
- `gateway.controlUi.allowedOrigins` に `https://openclaw.toof.jp` を追加

## 検証で判明したこと

設定済みプラグインは起動時の doctor が **npm から自動インストール**します(state PVC に永続化)。手動の `plugin add` は不要になったため README を更新しました。

```
- Installed missing configured plugin "anthropic-vertex" from @openclaw/anthropic-vertex-provider.
- Installed missing configured plugin "discord" from @openclaw/discord.
[gateway] agent model: anthropic-vertex/claude-sonnet-4-6 (thinking=adaptive, fast=off)
[gateway] ready
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
