### PR TITLE
ArgoCDのkustomizeビルドでHelmチャートインフレーションを有効化

### DIFF
--- a/kubernetes/applications/argocd/argocd-cm-patch.yaml
+++ b/kubernetes/applications/argocd/argocd-cm-patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  kustomize.buildOptions: --enable-helm

--- a/kubernetes/applications/argocd/kustomization.yaml
+++ b/kubernetes/applications/argocd/kustomization.yaml
@@ -11,3 +11,7 @@ patches:
       kind: ConfigMap
       name: argocd-cmd-params-cm
     path: argocd-cmd-params-cm-patch.yaml
+  - target:
+      kind: ConfigMap
+      name: argocd-cm
+    path: argocd-cm-patch.yaml


### PR DESCRIPTION
## 概要

`argocd-cm` に `kustomize.buildOptions: --enable-helm` をパッチで追加します。

## 背景

external-secretsアプリの `kustomization.yaml` は `helmCharts`(Helmチャートインフレーション)を使っていますが、ArgoCDのrepo-serverは `--enable-helm` なしではレンダリングを拒否するため、アプリが `ComparisonError`(`must specify --enable-helm`)で止まり、今後の変更が一切同期されない状態でした(Podは過去の同期のまま稼働中で実害は未発生)。

CIのkubeconform検証は既に `kustomize build --enable-helm` で実行しているため、ランタイム側の設定をCIと一致させます。

## 変更内容

- `argocd-cm-patch.yaml` を新規追加(既存の `argocd-cmd-params-cm-patch.yaml` と同じパターン)
- `kustomization.yaml` にパッチ参照を追加

## 検証済み

- `kubectl kustomize kubernetes/applications/argocd` で `argocd-cm` に `kustomize.buildOptions: --enable-helm` がマージされることを確認
- prettierチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)