### PR TITLE
fix: 巨大CRDをServer-Side Applyで同期しexternal-secretsチャートを固定

### DIFF
--- a/kubernetes/applications/argocd/applicationset-crd-patch.yaml
+++ b/kubernetes/applications/argocd/applicationset-crd-patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applicationsets.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true

--- a/kubernetes/applications/argocd/kustomization.yaml
+++ b/kubernetes/applications/argocd/kustomization.yaml
@@ -15,3 +15,7 @@ patches:
       kind: ConfigMap
       name: argocd-cm
     path: argocd-cm-patch.yaml
+  - target:
+      kind: CustomResourceDefinition
+      name: applicationsets.argoproj.io
+    path: applicationset-crd-patch.yaml

--- a/kubernetes/applications/external-secrets/crd-ssa-patch.yaml
+++ b/kubernetes/applications/external-secrets/crd-ssa-patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: placeholder
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true

--- a/kubernetes/applications/external-secrets/kustomization.yaml
+++ b/kubernetes/applications/external-secrets/kustomization.yaml
@@ -9,8 +9,14 @@ resources:
 helmCharts:
   - name: external-secrets
     repo: https://charts.external-secrets.io
+    version: 1.0.0
     releaseName: external-secrets
     namespace: external-secrets
     includeCRDs: true
     valuesInline:
       installCRDs: true
+patches:
+  - target:
+      kind: CustomResourceDefinition
+      name: ".*\\.external-secrets\\.io"
+    path: crd-ssa-patch.yaml


### PR DESCRIPTION
## 概要

argocd アプリと external-secrets アプリの sync エラーを解消します。

## 背景

- **argocd アプリ**: `applicationsets.argoproj.io` CRD が client-side apply の `last-applied-configuration` アノテーション上限 (262144 bytes) を超え、同期がリトライループに陥っていました。このため PR #154 の `--enable-helm` 設定 (`argocd-cm`) もクラスタに反映されていませんでした。
- **external-secrets アプリ**: Argo CD 導入前に手動 (server-side apply) でインストールされたもので、`secretstores` / `clustersecretstores` CRD は約 1MB あり client-side apply が不可能です。また kustomization にチャートバージョンの固定がありませんでした。

## 変更内容

- `applicationsets.argoproj.io` CRD に `argocd.argoproj.io/sync-options: ServerSideApply=true` を付与する kustomize パッチを追加
- external-secrets の全 CRD (23個) に同アノテーションを付与するパッチを追加
- external-secrets チャートを `1.0.0` に固定(稼働中の v1.0.0 と同一バージョンなので、既存リソースをバージョンジャンプなしで Argo CD 管理下に取り込めます)

## 検証

- `kubectl kustomize kubernetes/applications/argocd`: ビルド成功、SSA アノテーションは applicationsets CRD の 1 件のみ
- `kubectl kustomize --enable-helm kubernetes/applications/external-secrets`: ビルド成功、23 CRD 全てにアノテーション付与、image は稼働中と同じ `v1.0.0`

## マージ後の流れ

1. argocd アプリが自己修復し、CRD が SSA で apply され `--enable-helm` が `argocd-cm` に反映される
2. repo-server 再起動後、external-secrets アプリのレンダリングが通り、既存リソースが adopt される

🤖 Generated with [Claude Code](https://claude.com/claude-code)