### PR TITLE
fix: anthropic-vertex provider を明示定義して gateway 認証バグを回避

### DIFF
--- a/kubernetes/applications/openclaw/configmap.yaml
+++ b/kubernetes/applications/openclaw/configmap.yaml
@@ -25,6 +25,31 @@ data:
           }
         }
       },
+      "models": {
+        "providers": {
+          "anthropic-vertex": {
+            "baseUrl": "https://aiplatform.googleapis.com",
+            "api": "anthropic-messages",
+            "apiKey": "gcp-vertex-credentials",
+            "models": [
+              {
+                "id": "claude-sonnet-4-6",
+                "name": "Claude Sonnet 4.6",
+                "reasoning": true,
+                "input": ["text", "image"],
+                "cost": {
+                  "input": 3,
+                  "output": 15,
+                  "cacheRead": 0.3,
+                  "cacheWrite": 3.75
+                },
+                "contextWindow": 1000000,
+                "maxTokens": 128000
+              }
+            ]
+          }
+        }
+      },
       "channels": {
         "discord": {
           "enabled": true,
@@ -32,6 +57,17 @@ data:
             "source": "env",
             "provider": "default",
             "id": "DISCORD_BOT_TOKEN"
+          },
+          "groupPolicy": "allowlist",
+          "guilds": {
+            "1528017016407982250": {
+              "requireMention": true,
+              "channels": {
+                "1528044116045332622": {
+                  "enabled": true
+                }
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
## 概要

OpenClaw の cron ジョブが `Unknown model: anthropic-vertex/claude-sonnet-4-6` で失敗する問題の修正と、Discord サーバー内での会話設定です。

## 原因

OpenClaw の既知バグ [openclaw/openclaw#110103](https://github.com/openclaw/openclaw/issues/110103)(P1・未修正)。gateway 経路のエージェント実行はプラグインの暗黙カタログと synthetic ADC 認証フックを無視するため、`--local` やプラグイン単体では認証が通る(検証済み)のに、cron・チャンネル経由の実行だけモデル解決に失敗します。

## 変更内容

- **ワークアラウンド**: プラグインの暗黙カタログが生成するのと同じ provider 定義を `models.providers.anthropic-vertex` に明示的に記述(`apiKey` に非シークレットマーカー `gcp-vertex-credentials` を指定 → ADC 使用)
- **Discord 会話設定**: `groupPolicy: allowlist` でサーバー「ふみや」の #openclaw チャンネルを許可、メンションで応答(`requireMention: true`)

## 検証

ローカル Docker でこの設定 + ダミー SA 鍵を使い、gateway 経路の推論がモデル解決を通過して Google OAuth 取得段階まで到達することを確認済み(`rawError=Failed to acquire Google OAuth credentials` はダミー鍵による想定エラー)。クラスタの正規キーでは成功する見込みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
