### PR TITLE
Longhornのアップグレードを1.11.3経由の段階的な手順に修正

### DIFF
--- a/kubernetes/applications/longhorn.yaml
+++ b/kubernetes/applications/longhorn.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://charts.longhorn.io/
     chart: longhorn
-    targetRevision: 1.12.0
+    targetRevision: 1.11.3
     helm:
       valuesObject:
         preUpgradeChecker:


### PR DESCRIPTION
## 概要

Longhornのchart `targetRevision` を 1.12.0 → **1.11.3** に変更します(1.12.0を経由アップグレード後に再バンプ予定)。

## 背景

- Renovateが2026-07-16にchartを1.10.1→1.12.0へバンプ(a40147c)しましたが、longhornアプリはautomated syncなしのため未適用で、クラスタは**v1.10.1のまま**稼働しています(ArgoCDでOutOfSyncとして滞留。42リソースの差分の実体はこの保留中アップグレード)
- Longhornがサポートするのは**1マイナーずつの**アップグレードのみ(1.10→1.11→1.12)。1.10.1→1.12.0の直接syncは非サポートです
- さらに本クラスタは `preUpgradeChecker.jobEnabled: false`(ArgoCD運用の推奨設定)のため、非サポートアップグレードを拒否する安全弁が働きません。このままsyncすると稼働中ボリューム(immich-library等)を抱えたまま非サポート経路で進行するリスクがありました

## 手順

1. 本PRマージ後、手動syncで **1.10.1 → 1.11.3** を実施し、ボリューム・ノードの正常性を確認
2. 安定確認後、**1.12.0** へ再バンプして再度手動sync
3. フォローアップ: Renovateがlonghornのマイナーを飛ばしてバンプしないよう設定検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)