### PR TITLE
Longhornのengine自動ライブアップグレードを有効化

### DIFF
--- a/kubernetes/applications/longhorn.yaml
+++ b/kubernetes/applications/longhorn.yaml
@@ -17,6 +17,7 @@ spec:
         defaultSettings:
           taintToleration: node-role.kubernetes.io/control-plane=:NoSchedule
           defaultReplicaCount: 1
+          concurrentAutomaticEngineUpgradePerNodeLimit: 1
         persistence:
           defaultClassReplicaCount: 1
         longhornManager:


### PR DESCRIPTION
## 概要

`defaultSettings.concurrentAutomaticEngineUpgradePerNodeLimit: 1` を追加します。

## 背景

1.11.3へのchart同期(PR #159)後、managerはv1.11.3になりましたが、全ボリューム(32 engine参照)は**v1.10.1のengineのまま**です。`concurrent-automatic-engine-upgrade-per-node-limit` がデフォルト `0`(自動engineアップグレード無効)のためです。

この設定を `1` にすると、Longhornがノードごとに1ボリュームずつ、無停止のライブアップグレードでengineをデフォルトengine image(v1.11.3)へ順次移行します。1.12.0へのバンプ前にmanagerとengineの版差を解消しておくのが目的で、永続設定なので今後のアップグレードでも自動追従します。

## 検証手順(マージ後)

- `kubectl get engineimages.longhorn.io -n longhorn-system` でv1.10.1のREFCOUNTが0まで減り、v1.11.3側へ移ることを確認
- ボリュームのrobustnessがhealthyを維持することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)