### PR TITLE
Longhorn chartを1.12.0へアップグレード

### DIFF
--- a/kubernetes/applications/longhorn.yaml
+++ b/kubernetes/applications/longhorn.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://charts.longhorn.io/
     chart: longhorn
-    targetRevision: 1.11.3
+    targetRevision: 1.12.0
     helm:
       valuesObject:
         preUpgradeChecker:


### PR DESCRIPTION
## 概要

段階アップグレードの最終ステップとして、chart `targetRevision` を 1.11.3 → **1.12.0** に変更します。

## 背景

PR #159・#160の流れの続きです:

- 1.10.1 → 1.11.3 の同期完了(manager全ノードv1.11.3)
- engine自動ライブアップグレード有効化により、全32 engine参照がv1.11.3へ移行済み(v1.10.1のREFCOUNT: 0)
- ボリュームは移行中もhealthyを維持(9 healthy / 1 unknownは既存のdetachedボリューム)

manager/engineがv1.11.3に揃ったため、1.12.0への1マイナーアップグレードはサポート範囲内です。

## マージ後の手順

1. 手動sync(longhornアプリはautomated syncなし)
2. manager DaemonSetのロールアウトとPod正常性を確認
3. engineの自動ライブアップグレード(v1.11.3 → v1.12.0)の完了とボリュームhealthy維持を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)