### PR TITLE
feat: step longhorn minor upgrades separately in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "kubernetes": {
-    "managerFilePatterns": [
-      "/^kubernetes/.+\\.yaml$/"
-    ]
+    "managerFilePatterns": ["/^kubernetes/.+\\.yaml$/"]
   },
   "argocd": {
-    "managerFilePatterns": [
-      "/^kubernetes/applications/.+\\.yaml$/"
-    ]
+    "managerFilePatterns": ["/^kubernetes/applications/.+\\.yaml$/"]
   },
   "packageRules": [
     {
       "matchDatasources": ["docker"],
       "matchCurrentValue": "latest",
       "pinDigests": true
+    },
+    {
+      "matchPackageNames": ["longhorn"],
+      "separateMultipleMinor": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

renovate.jsonに、longhornのマイナーバージョンストリームごとに個別PRを作らせる`separateMultipleMinor`ルールを追加します。

## 背景

Longhornは1マイナーずつのアップグレードのみサポートしますが、Renovateが1.10.1→1.12.0へ1.11系を飛ばしてバンプし、手動での段階的な巻き戻し(PR #159/#160/#162)が必要になりました。このルールにより、今後は1.11.x・1.12.x…とマイナーごとにPRが分かれ、順番に適用できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)