### PR TITLE
feat: OpenClaw の Discord DM を無効化

### DIFF
--- a/kubernetes/applications/openclaw/configmap.yaml
+++ b/kubernetes/applications/openclaw/configmap.yaml
@@ -59,6 +59,7 @@ data:
             "id": "DISCORD_BOT_TOKEN"
           },
           "groupPolicy": "allowlist",
+          "dmPolicy": "disabled",
           "guilds": {
             "1528017016407982250": {
               "requireMention": true,


### PR DESCRIPTION
## 概要

DM は使わない方針のため `channels.discord.dmPolicy: "disabled"` を明示します。会話はサーバー「ふみや」の #openclaw チャンネルでの @メンションのみになります。

マージ後の反映には `kubectl -n openclaw rollout restart deploy/openclaw` が必要です(クォータ開通前なら急ぎません。次の再起動時に反映されれば十分です)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)