### PR TITLE
feat: add Actions Runner Controller with dotfiles runner scale set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+kubernetes/applications/*/charts/

--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -10,6 +10,10 @@ spec:
         elements:
           - name: archiveteam-warrior
             namespace: archiveteam-warrior
+          - name: arc-runners
+            namespace: arc-runners
+          - name: arc-systems
+            namespace: arc-systems
           - name: argocd
             namespace: argocd
           - name: bbs

--- a/kubernetes/applications/arc-runners/arc-dotfiles-values.yaml
+++ b/kubernetes/applications/arc-runners/arc-dotfiles-values.yaml
@@ -1,0 +1,24 @@
+---
+githubConfigUrl: https://github.com/toof-jp/dotfiles
+githubConfigSecret: arc-dotfiles-github-app
+minRunners: 1
+maxRunners: 1
+controllerServiceAccount:
+  namespace: arc-systems
+  name: arc-gha-rs-controller
+template:
+  spec:
+    securityContext:
+      fsGroup: 1001
+      fsGroupChangePolicy: OnRootMismatch
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:2.335.1
+        command: ["/home/runner/run.sh"]
+        volumeMounts:
+          - name: nix
+            mountPath: /nix
+    volumes:
+      - name: nix
+        persistentVolumeClaim:
+          claimName: arc-dotfiles-nix

--- a/kubernetes/applications/arc-runners/external-secret.yaml
+++ b/kubernetes/applications/arc-runners/external-secret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: arc-dotfiles-github-app-external-secret
+  namespace: arc-runners
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: arc-dotfiles-github-app
+  data:
+    - secretKey: github_app_id
+      remoteRef:
+        key: arc-github-app-id
+    - secretKey: github_app_installation_id
+      remoteRef:
+        key: arc-github-app-installation-id
+    - secretKey: github_app_private_key
+      remoteRef:
+        key: arc-github-app-private-key

--- a/kubernetes/applications/arc-runners/kustomization.yaml
+++ b/kubernetes/applications/arc-runners/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: arc-runners
+resources:
+  - namespace.yaml
+  - external-secret.yaml
+  - pvc.yaml
+helmCharts:
+  - name: gha-runner-scale-set
+    repo: oci://ghcr.io/actions/actions-runner-controller-charts
+    version: 0.14.2
+    releaseName: arc-dotfiles
+    namespace: arc-runners
+    valuesFile: arc-dotfiles-values.yaml

--- a/kubernetes/applications/arc-runners/namespace.yaml
+++ b/kubernetes/applications/arc-runners/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: arc-runners

--- a/kubernetes/applications/arc-runners/pvc.yaml
+++ b/kubernetes/applications/arc-runners/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: arc-dotfiles-nix
+  namespace: arc-runners
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/kubernetes/applications/arc-systems/kustomization.yaml
+++ b/kubernetes/applications/arc-systems/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: arc-systems
+resources:
+  - namespace.yaml
+helmCharts:
+  - name: gha-runner-scale-set-controller
+    repo: oci://ghcr.io/actions/actions-runner-controller-charts
+    version: 0.14.2
+    releaseName: arc
+    namespace: arc-systems

--- a/kubernetes/applications/arc-systems/namespace.yaml
+++ b/kubernetes/applications/arc-systems/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: arc-systems


### PR DESCRIPTION
## 概要

toof-jp/dotfiles の CI をクラスタ上で実行するため、Actions Runner Controller(runner scale set 方式、v0.14.2)を導入します。dotfiles 側の高速化施策(toof-jp/dotfiles#27 の Cachix 導入)の続きで、warm な /nix ストアを持つ self-hosted runner により substitute 自体を不要にするのが目的です。

## 変更内容

- `arc-systems`: `gha-runner-scale-set-controller` チャート(kustomize helmCharts、OCI レジストリ直接参照)
- `arc-runners`: `gha-runner-scale-set` チャート
  - runner scale set 名 `arc-dotfiles`(workflow の `runs-on: arc-dotfiles` で使用)
  - `/nix` を Longhorn PVC(50Gi, RWO)に永続化。独立した nix プロセス同士は同一ストアを安全に共有できないため `minRunners: 1` / `maxRunners: 1` で直列化(ジョブ間でストアを共有できるので、3 つの NixOS 構成は closure の大半が重なり直列でも速い見込み)
  - `fsGroup: 1001`(runner ユーザ)+ `OnRootMismatch` で初回のみ chown
  - GitHub App 認証情報は GCP Secret Manager → ExternalSecret
- kustomize が build 時に落とすチャートキャッシュ `kubernetes/applications/*/charts/` を .gitignore に追加

## マージ前に必要な作業

1. GitHub App を作成(個人アカウントで可): Repository permissions = Actions (Read) / Administration (Read & Write) / Metadata (Read)、toof-jp/dotfiles にインストール
2. GCP Secret Manager(project: toof-infra)に以下を登録
   - `arc-github-app-id`
   - `arc-github-app-installation-id`
   - `arc-github-app-private-key`(PEM そのまま)

## マージ後の確認

- arc-systems → arc-runners の順に sync(AutoscalingRunnerSet CRD が先に必要。初回は arc-runners の sync が一時的に失敗してもリトライで収束するはず)
- `kubectl get pods -n arc-runners` で listener + runner Pod を確認
- dotfiles リポジトリの Settings > Actions > Runners に `arc-dotfiles` が現れることを確認

## 補足(セキュリティ)

dotfiles は public リポジトリのため、fork PR 対策として Settings > Actions > "Require approval for all outside collaborators" を推奨します。workflow の切り替え(`runs-on: arc-dotfiles`)は dotfiles 側の別 PR で行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)