### PR TITLE
fix: include ARC CRDs in arc-systems chart inflation

### DIFF
--- a/kubernetes/applications/arc-systems/kustomization.yaml
+++ b/kubernetes/applications/arc-systems/kustomization.yaml
@@ -10,3 +10,4 @@ helmCharts:
     version: 0.14.2
     releaseName: arc
     namespace: arc-systems
+    includeCRDs: true


### PR DESCRIPTION
## 概要

#167 の修正です。kustomize の helm chart inflation は `includeCRDs: true` を指定しない限りチャートの `crds/` ディレクトリを出力しないため、ARC の CRD が一切適用されず

- `arc-gha-rs-controller` が `no matches for kind "EphemeralRunnerSet"` でクラッシュループ
- `arc-runners` が `AutoscalingRunnerSet` CRD 不在で sync 失敗

になっていました。external-secrets の kustomization と同様に `includeCRDs: true` を追加します(CRD 4 つがレンダリングされることをローカルの kustomize 5.7.1 + helm 3.19 で確認済み)。

マージ後は arc-systems → arc-runners の順に自動 sync で収束するはずです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)