### PR TITLE
fix: server-side apply ARC CRDs

### DIFF
--- a/kubernetes/applications/arc-systems/crd-ssa-patch.yaml
+++ b/kubernetes/applications/arc-systems/crd-ssa-patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: placeholder
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true

--- a/kubernetes/applications/arc-systems/kustomization.yaml
+++ b/kubernetes/applications/arc-systems/kustomization.yaml
@@ -11,3 +11,8 @@ helmCharts:
     releaseName: arc
     namespace: arc-systems
     includeCRDs: true
+patches:
+  - target:
+      kind: CustomResourceDefinition
+      name: ".*\\.actions\\.github\\.com"
+    path: crd-ssa-patch.yaml


### PR DESCRIPTION
## 概要

#168 の後、ARC の CRD が client-side apply の 256KB アノテーション上限に引っかかり sync 失敗していました(external-secrets #155 で踏んだのと同じ問題):

```
CustomResourceDefinition "autoscalingrunnersets.actions.github.com" is invalid:
metadata.annotations: Too long: may not be more than 262144 bytes
```

external-secrets と同じ `argocd.argoproj.io/sync-options: ServerSideApply=true` パッチを ARC の CRD 4 つに適用します。

kustomize build でアノテーションが CRD に付与されることを確認済みです。マージ後は arc-systems → arc-runners の順に自動で収束するはずです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)