### PR TITLE
feat: add arc-infra runner scale set for argocd-diff-preview

### DIFF
--- a/.github/workflows/argocd-diff-preview.yaml
+++ b/.github/workflows/argocd-diff-preview.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   diff-preview:
-    runs-on: ubuntu-latest
+    runs-on: arc-infra
     permissions:
       contents: read
       pull-requests: write

--- a/kubernetes/applications/arc-runners/arc-dotfiles-values.yaml
+++ b/kubernetes/applications/arc-runners/arc-dotfiles-values.yaml
@@ -1,6 +1,6 @@
 ---
 githubConfigUrl: https://github.com/toof-jp/dotfiles
-githubConfigSecret: arc-dotfiles-github-app
+githubConfigSecret: arc-github-app
 minRunners: 1
 maxRunners: 1
 controllerServiceAccount:

--- a/kubernetes/applications/arc-runners/arc-infra-values.yaml
+++ b/kubernetes/applications/arc-runners/arc-infra-values.yaml
@@ -1,0 +1,60 @@
+---
+githubConfigUrl: https://github.com/toof-jp/infra
+githubConfigSecret: arc-github-app
+minRunners: 0
+maxRunners: 1
+controllerServiceAccount:
+  namespace: arc-systems
+  name: arc-gha-rs-controller
+template:
+  spec:
+    initContainers:
+      - name: init-dind-externals
+        image: ghcr.io/actions/actions-runner:2.335.1
+        command:
+          ["cp", "-r", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+        volumeMounts:
+          - name: dind-externals
+            mountPath: /home/runner/tmpDir
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:2.335.1
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: DOCKER_HOST
+            value: unix:///var/run/docker.sock
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: dind-sock
+            mountPath: /var/run
+      - name: dind
+        image: docker:29.6.2-dind
+        args:
+          - dockerd
+          - --host=unix:///var/run/docker.sock
+          - --group=$(DOCKER_GROUP_GID)
+        env:
+          - name: DOCKER_GROUP_GID
+            value: "123"
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: dind-sock
+            mountPath: /var/run
+          - name: dind-externals
+            mountPath: /home/runner/externals
+          - name: docker-data
+            mountPath: /var/lib/docker
+    volumes:
+      - name: work
+        emptyDir: {}
+      - name: dind-sock
+        emptyDir: {}
+      - name: dind-externals
+        emptyDir: {}
+      - name: docker-data
+        persistentVolumeClaim:
+          claimName: arc-infra-docker

--- a/kubernetes/applications/arc-runners/external-secret.yaml
+++ b/kubernetes/applications/arc-runners/external-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: arc-dotfiles-github-app-external-secret
+  name: arc-github-app-external-secret
   namespace: arc-runners
 spec:
   refreshPolicy: CreatedOnce
@@ -10,7 +10,7 @@ spec:
     name: gcp-secret-manager
     kind: ClusterSecretStore
   target:
-    name: arc-dotfiles-github-app
+    name: arc-github-app
   data:
     - secretKey: github_app_id
       remoteRef:

--- a/kubernetes/applications/arc-runners/kustomization.yaml
+++ b/kubernetes/applications/arc-runners/kustomization.yaml
@@ -13,3 +13,9 @@ helmCharts:
     releaseName: arc-dotfiles
     namespace: arc-runners
     valuesFile: arc-dotfiles-values.yaml
+  - name: gha-runner-scale-set
+    repo: oci://ghcr.io/actions/actions-runner-controller-charts
+    version: 0.14.2
+    releaseName: arc-infra
+    namespace: arc-runners
+    valuesFile: arc-infra-values.yaml

--- a/kubernetes/applications/arc-runners/pvc.yaml
+++ b/kubernetes/applications/arc-runners/pvc.yaml
@@ -10,3 +10,15 @@ spec:
   resources:
     requests:
       storage: 50Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: arc-infra-docker
+  namespace: arc-runners
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi


### PR DESCRIPTION
## 概要

infra の CI のうち一番遅い argocd-diff-preview を self-hosted runner(`arc-infra`)に載せます。

## 変更内容

- `arc-infra` runner scale set を追加(`runs-on: arc-infra`)
  - diff-preview は docker で ephemeral クラスタを起動するため、dind サイドカー付きのカスタム template(ARC 公式ドキュメントの dind 構成)
  - `/var/lib/docker` を 30Gi PVC に永続化。kind ノード等 ~1.5GB のイメージ pull が初回だけになり、2 回目以降は家庭回線に依存しない。キャッシュが RWO のため `maxRunners: 1`
  - ジョブは k8s 変更のある PR でしか走らないので `minRunners: 0`(コールドスタートは Pod 起動の数十秒)
- GitHub App secret を dotfiles と共用するため `arc-dotfiles-github-app` → `arc-github-app` にリネーム(未デプロイなので影響なし)
- format-yaml / terraform-fmt / validate-kubernetes は数十秒で終わるため hosted のまま

## マージ前に必要な作業

- GitHub App(installation 147508349)のリポジトリアクセスに **toof-jp/infra を追加**: https://github.com/settings/installations/147508349 → Repository access

## 依存

- #169(ARC CRD の ServerSideApply 修正)が先にマージされ、arc-systems / arc-runners が Synced になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)