### PR TITLE
fix: mount host cgroup and modules into arc-infra dind for kind

### DIFF
--- a/kubernetes/applications/arc-runners/arc-dotfiles-values.yaml
+++ b/kubernetes/applications/arc-runners/arc-dotfiles-values.yaml
@@ -8,6 +8,8 @@ controllerServiceAccount:
   name: arc-gha-rs-controller
 template:
   spec:
+    nodeSelector:
+      kubernetes.io/hostname: zen2
     securityContext:
       fsGroup: 1001
       fsGroupChangePolicy: OnRootMismatch

--- a/kubernetes/applications/arc-runners/arc-infra-values.yaml
+++ b/kubernetes/applications/arc-runners/arc-infra-values.yaml
@@ -8,6 +8,8 @@ controllerServiceAccount:
   name: arc-gha-rs-controller
 template:
   spec:
+    nodeSelector:
+      kubernetes.io/hostname: zen2
     initContainers:
       - name: init-dind-externals
         image: ghcr.io/actions/actions-runner:2.335.1
@@ -48,6 +50,11 @@ template:
             mountPath: /home/runner/externals
           - name: docker-data
             mountPath: /var/lib/docker
+          - name: cgroup
+            mountPath: /sys/fs/cgroup
+          - name: modules
+            mountPath: /lib/modules
+            readOnly: true
     volumes:
       - name: work
         emptyDir: {}
@@ -58,3 +65,11 @@ template:
       - name: docker-data
         persistentVolumeClaim:
           claimName: arc-infra-docker
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory


### PR DESCRIPTION
## 概要

arc-infra での argocd-diff-preview 初回実行が kind クラスタ作成で失敗しました:

```
ERROR: failed to create cluster: could not find a log line that matches
"Reached target .*Multi-User System.*|detected cgroup v1"
```

kind のノードコンテナは内部で systemd を起動するため、Pod 内 dind で動かす場合はホストの cgroup2 階層とカーネルモジュールが必要です(kind 公式の kind-in-Kubernetes 構成と同じ対応)。

## 変更内容

- arc-infra の dind コンテナに hostPath `/sys/fs/cgroup`(rw)と `/lib/modules`(ro)をマウント
- 両 scale set(arc-infra / arc-dotfiles)に `nodeSelector: kubernetes.io/hostname: zen2` を追加
  - VPS ノード(2〜4 vCPU / 4GB)では kind + Argo CD が動かない
  - runner の PVC(nix ストア / docker キャッシュ)も zen2 にあるため配置を固定

## マージ後の確認

- PR(この PR 自身でも可)で diff-preview が self-hosted で通ること
- 2 回目以降は docker キャッシュが効いて pull なしで走ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)