### PR TITLE
feat: restrict vultr ssh to tailscale-only

### DIFF
--- a/terraform/vultr.tf
+++ b/terraform/vultr.tf
@@ -6,7 +6,8 @@
 #   1. make vultr-iso, upload result somewhere Vultr can reach, set
 #      vultr_iso_url
 #   2. apply — instance boots the installer; ssh root@<ip>, run
-#      `vultr-install`
+#      `vultr-install` (the firewall blocks public SSH, so reach the
+#      installer via the Vultr web console or a temporary SSH rule)
 #   3. set vultr_attach_iso = false, apply — detaches the ISO so the
 #      instance boots NixOS from disk
 
@@ -20,29 +21,11 @@ resource "vultr_ssh_key" "toof" {
   ssh_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIN8H2c3Qa2EsEh6RQG6nRoRFblH8fj5dHj9YyVD9tND toof@toof.jp"
 }
 
-# Cluster traffic (apiserver, etcd, kubelet) flows over the Tailscale mesh,
-# so only SSH and Tailscale's WireGuard port are exposed publicly — same
-# policy as sakura-vps's NixOS firewall.
+# Cluster traffic (apiserver, etcd, kubelet) and SSH flow over the Tailscale
+# mesh, so only Tailscale's WireGuard port is exposed publicly. SSH reaches
+# the node via its tailnet address, never the public IP.
 resource "vultr_firewall_group" "k8s_node" {
-  description = "k8s node: ssh + tailscale only"
-}
-
-resource "vultr_firewall_rule" "ssh_v4" {
-  firewall_group_id = vultr_firewall_group.k8s_node.id
-  protocol          = "tcp"
-  ip_type           = "v4"
-  subnet            = "0.0.0.0"
-  subnet_size       = 0
-  port              = "22"
-}
-
-resource "vultr_firewall_rule" "ssh_v6" {
-  firewall_group_id = vultr_firewall_group.k8s_node.id
-  protocol          = "tcp"
-  ip_type           = "v6"
-  subnet            = "::"
-  subnet_size       = 0
-  port              = "22"
+  description = "k8s node: tailscale only"
 }
 
 resource "vultr_firewall_rule" "tailscale_v4" {


### PR DESCRIPTION
## 概要
- vultr-vps のファイアウォールから公開 SSH(22/tcp)の許可ルール(`ssh_v4` / `ssh_v6`)を削除
- 公開側に開くのは Tailscale の WireGuard ポート(41641/udp)と ICMP のみ
- SSH は今後 Tailscale メッシュ経由(tailnet アドレス宛)でのみ到達可能

## 注意
- マージ前に、Tailscale 経由で vultr-vps に SSH できることを確認してください(公開 IP 経由の SSH は apply 後に遮断されます)
- 再インストール時は installer に公開 SSH で入れなくなるため、Vultr の Web コンソールか一時的な SSH ルールを使う想定(vultr.tf のコメントに追記済み)

## テスト
- [x] `terraform fmt -check`
- [x] `terraform validate`
- [ ] HCP Terraform の plan で ssh_v4 / ssh_v6 の destroy のみ(2 destroy)であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)