### PR TITLE
fix: replace fsGroup with init chown on the arc-dotfiles nix volume

### DIFF
--- a/kubernetes/applications/arc-runners/arc-dotfiles-values.yaml
+++ b/kubernetes/applications/arc-runners/arc-dotfiles-values.yaml
@@ -10,9 +10,15 @@ template:
   spec:
     nodeSelector:
       kubernetes.io/hostname: zen2
-    securityContext:
-      fsGroup: 1001
-      fsGroupChangePolicy: OnRootMismatch
+    initContainers:
+      - name: init-nix-owner
+        image: ghcr.io/actions/actions-runner:2.335.1
+        command: ["sh", "-c", "chown runner:runner /nix && chmod g-s /nix"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: nix
+            mountPath: /nix
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:2.335.1


### PR DESCRIPTION
## 概要

arc-dotfiles での nix ビルドが全 derivation で `chmod: Operation not permitted` になる問題の修正です。

原因の連鎖:

1. kubelet の `fsGroup` が PVC 上の全ディレクトリに **setgid ビット**を付与する
2. setgid ディレクトリ配下に作られるディレクトリは setgid を継承する
3. nix はビルダーに「mode に setuid/setgid を含む chmod を EPERM にする」**seccomp フィルタ**を適用している
4. stdenv の `chmod -R u+w` は現在モード(2755)を保持した絶対モードで chmod するため、全ビルドが EPERM で失敗

対処として `fsGroup` をやめ、root の initContainer で `/nix` の chown(+ ルートの setgid 解除)を行います。

## マージ後に必要な作業(私がやります)

- ボリューム上に既に付いてしまった setgid ビットの一掃(`find /nix -perm -2000 -exec chmod g-s {} +`)
- dotfiles CI の再実行で green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)