### PR TITLE
feat(terraform): adopt OCI free-tier resources and oci-vps instance

### DIFF
--- a/terraform/hcp_terraform.tf
+++ b/terraform/hcp_terraform.tf
@@ -101,6 +101,25 @@ locals {
       # the hcl flag on a sensitive variable, so keep managing it as-is.
       hcl = false
     }
+    oci_tenancy_ocid = {
+      value     = var.oci_tenancy_ocid
+      sensitive = false
+    }
+    oci_user_ocid = {
+      value     = var.oci_user_ocid
+      sensitive = false
+    }
+    oci_fingerprint = {
+      value     = var.oci_fingerprint
+      sensitive = false
+    }
+    oci_private_key = {
+      value     = var.oci_private_key
+      sensitive = true
+      # Seeded via the TFE API with hcl=false; same constraint as
+      # vultr_api_key above.
+      hcl = false
+    }
     AWS_ACCESS_KEY_ID = {
       value     = local.aws_access_key_id_value
       sensitive = true

--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -1,0 +1,23 @@
+# The oci_* workspace variables were seeded via the TFE API (the plan needs
+# OCI credentials before tfe_variable.infra_variables can create them), so
+# adopt them into state instead of recreating. These blocks are no-ops once
+# imported and can be removed afterwards.
+import {
+  to = tfe_variable.infra_variables["oci_tenancy_ocid"]
+  id = "toof-infra/toof-infra/var-KibjxGmV3jbQ9xGj"
+}
+
+import {
+  to = tfe_variable.infra_variables["oci_user_ocid"]
+  id = "toof-infra/toof-infra/var-bwqQzYvXe6m22thf"
+}
+
+import {
+  to = tfe_variable.infra_variables["oci_fingerprint"]
+  id = "toof-infra/toof-infra/var-SGpkNx4JuYsujqUv"
+}
+
+import {
+  to = tfe_variable.infra_variables["oci_private_key"]
+  id = "toof-infra/toof-infra/var-dCM1vTTHcz6G7JM6"
+}

--- a/terraform/oci.tf
+++ b/terraform/oci.tf
@@ -1,0 +1,162 @@
+# OCI always-free resources (ap-osaka-1, root compartment). The VCN and its
+# defaults were hand-created in the console (2025-08) and are adopted here
+# via import blocks; display names keep their console-generated values so
+# the import is a no-op.
+
+import {
+  to = oci_core_vcn.k8s
+  id = "ocid1.vcn.oc1.ap-osaka-1.amaaaaaalfc45kiajf44goeyv72cooo4m5g436l32uc5pqmpyy2vdcpofpya"
+}
+
+resource "oci_core_vcn" "k8s" {
+  compartment_id = var.oci_tenancy_ocid
+  cidr_blocks    = ["10.0.0.0/16"]
+  display_name   = "vcn-20250817-0330"
+  dns_label      = "vcn08170335"
+}
+
+import {
+  to = oci_core_internet_gateway.k8s
+  id = "ocid1.internetgateway.oc1.ap-osaka-1.aaaaaaaai6obj7b4nnreibye3iegqb6f2ha5pjpyvxfxayq5dsvxi7mke2xq"
+}
+
+resource "oci_core_internet_gateway" "k8s" {
+  compartment_id = var.oci_tenancy_ocid
+  vcn_id         = oci_core_vcn.k8s.id
+  display_name   = "Internet Gateway vcn-20250817-0330"
+  enabled        = true
+}
+
+import {
+  to = oci_core_default_route_table.k8s
+  id = "ocid1.routetable.oc1.ap-osaka-1.aaaaaaaat7qrn5oynzlvklmxxwwkh3rcc64duuynvcfia7fqn3whfvjjqkba"
+}
+
+resource "oci_core_default_route_table" "k8s" {
+  manage_default_resource_id = oci_core_vcn.k8s.default_route_table_id
+  display_name               = "Default Route Table for vcn-20250817-0330"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.k8s.id
+  }
+}
+
+import {
+  to = oci_core_default_security_list.k8s
+  id = "ocid1.securitylist.oc1.ap-osaka-1.aaaaaaaah7xzf7mq53w4kyxe46gtv55eoodgutozyjsgtnxn33lwdx5lavsa"
+}
+
+resource "oci_core_default_security_list" "k8s" {
+  manage_default_resource_id = oci_core_vcn.k8s.default_security_list_id
+  display_name               = "Default Security List for vcn-20250817-0330"
+
+  egress_security_rules {
+    destination      = "0.0.0.0/0"
+    destination_type = "CIDR_BLOCK"
+    protocol         = "all"
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "1"
+    source   = "0.0.0.0/0"
+  }
+
+  ingress_security_rules {
+    protocol = "1"
+    source   = "10.0.0.0/16"
+
+    icmp_options {
+      type = 3
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 443
+      max = 443
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 80
+      max = 80
+    }
+  }
+}
+
+import {
+  to = oci_core_subnet.k8s
+  id = "ocid1.subnet.oc1.ap-osaka-1.aaaaaaaaajufxp6owv7x23o37w25wt5pnpgoackc6svpwxjkcxilztwgtnta"
+}
+
+resource "oci_core_subnet" "k8s" {
+  compartment_id = var.oci_tenancy_ocid
+  vcn_id         = oci_core_vcn.k8s.id
+  cidr_block     = "10.0.0.0/24"
+  display_name   = "subnet-20250817-0330"
+  dns_label      = "subnet08170335"
+}
+
+# oci-vps: always-free E2.1.Micro intended to join the k8s cluster over
+# Tailscale (same policy as vultr-vps). Launched via the OCI CLI on
+# 2026-07-19 and adopted here.
+import {
+  to = oci_core_instance.oci_vps
+  id = "ocid1.instance.oc1.ap-osaka-1.anvwsljrlfc45kicc74hfyeusg5ujhnl2rhdjfkrajbjb2qpph2laf7a545q"
+}
+
+resource "oci_core_instance" "oci_vps" {
+  compartment_id      = var.oci_tenancy_ocid
+  availability_domain = "yPbU:AP-OSAKA-1-AD-1"
+  shape               = "VM.Standard.E2.1.Micro"
+  display_name        = "oci-vps"
+
+  source_details {
+    source_type             = "image"
+    source_id               = "ocid1.image.oc1.ap-osaka-1.aaaaaaaakkk2ftbt2ztpw3jdriwhadh4xi4rbdi4fspi2xcv27cx7xqj45pq"
+    boot_volume_size_in_gbs = 100
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.k8s.id
+    assign_public_ip = true
+    hostname_label   = "oci-vps"
+  }
+
+  metadata = {
+    ssh_authorized_keys = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIN8H2c3Qa2EsEh6RQG6nRoRFblH8fj5dHj9YyVD9tND toof@toof.jp"
+  }
+
+  lifecycle {
+    # The workspace auto-applies; never let a drifted attribute replace the
+    # always-free instance (capacity may be unrecoverable).
+    prevent_destroy = true
+  }
+}
+
+output "oci_vps_public_ip" {
+  value = oci_core_instance.oci_vps.public_ip
+}
+
+output "oci_vps_private_ip" {
+  value = oci_core_instance.oci_vps.private_ip
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -35,6 +35,11 @@ terraform {
       version = "~> 2"
     }
 
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 8"
+    }
+
     terraform = {
       source = "terraform.io/builtin/terraform"
     }
@@ -80,4 +85,12 @@ provider "auth0" {
 }
 provider "vultr" {
   api_key = var.vultr_api_key
+}
+
+provider "oci" {
+  tenancy_ocid = var.oci_tenancy_ocid
+  user_ocid    = var.oci_user_ocid
+  fingerprint  = var.oci_fingerprint
+  private_key  = var.oci_private_key
+  region       = "ap-osaka-1"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -89,3 +89,22 @@ variable "vultr_attach_iso" {
   description = "Boot the instance from the installer ISO. Set to false after `vultr-install` so the node boots NixOS from disk."
   default     = false
 }
+
+variable "oci_tenancy_ocid" {
+  type = string
+}
+
+variable "oci_user_ocid" {
+  type = string
+}
+
+variable "oci_fingerprint" {
+  type        = string
+  description = "Fingerprint of the OCI API signing key."
+}
+
+variable "oci_private_key" {
+  type        = string
+  sensitive   = true
+  description = "PEM private key for OCI API signing."
+}


### PR DESCRIPTION
## 概要

手作業で作っていたOCI Always Freeのリソース群をTerraform管理に取り込み、k8sノード候補となる新インスタンス `oci-vps` を追加します。

### importするリソース（import block方式、mainマージ時のリモートrunで取り込み）

- `oci_core_vcn.k8s` — vcn-20250817-0330 (10.0.0.0/16)
- `oci_core_subnet.k8s` — subnet-20250817-0330 (10.0.0.0/24)
- `oci_core_internet_gateway.k8s`
- `oci_core_default_route_table.k8s` — 0.0.0.0/0 → IGW
- `oci_core_default_security_list.k8s` — SSH/HTTP/HTTPS/ICMP（現状のまま）
- `oci_core_instance.oci_vps` — **新規作成済み** E2.1.Micro (amd64, 1 OCPU/1GB, Ubuntu 24.04, boot 100GB, 10.0.0.223 / 161.33.12.226)。vultr-vps同様、後続PRでTailscale経由のk8sノード（まずworker、余裕があればcontrol-plane）にする予定
- `tfe_variable.infra_variables["oci_*"]` — 認証変数4つ（TFE APIでseed済みのため422回避のimport。取り込み後にimports.tfのblockは削除可）

### 認証まわり

- `oracle/oci` provider (~> 8) を追加。regionは `ap-osaka-1` を直書き
- `oci_tenancy_ocid` / `oci_user_ocid` / `oci_fingerprint` / `oci_private_key`（sensitive, hcl=false）はワークスペースにseed済み

### 安全対策

- ワークスペースはauto-applyのため、`oci_core_instance.oci_vps` に `prevent_destroy = true` を設定（Always Free枠のインスタンスが誤ったreplace planで消えるのを防止）

## 補足

- 旧インスタンス `instance-20260120-2338`（旧Micro）はimport対象外。動作確認後に削除予定
- 孤児ブートボリューム3つ（計141GB）はクォータ確保のため削除済み
- A1.Flex (ARM) はOut of host capacityが解消せず断念、AMD Microを採用

🤖 Generated with [Claude Code](https://claude.com/claude-code)