### PR TITLE
feat: add palworld server

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -46,6 +46,8 @@ spec:
             namespace: obsidian-msp
           - name: openclaw
             namespace: openclaw
+          - name: palworld
+            namespace: palworld
           - name: shisha-log
             namespace: shisha-log
   template:

--- a/kubernetes/applications/palworld/external-secret.yaml
+++ b/kubernetes/applications/palworld/external-secret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: palworld-external-secret
+  namespace: palworld
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: palworld-secret
+  data:
+    - secretKey: SERVER_PASSWORD
+      remoteRef:
+        key: palworld-server-password

--- a/kubernetes/applications/palworld/namespace.yaml
+++ b/kubernetes/applications/palworld/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: palworld

--- a/kubernetes/applications/palworld/palworld.yaml
+++ b/kubernetes/applications/palworld/palworld.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: palworld-data
+  namespace: palworld
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: palworld
+  namespace: palworld
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: palworld
+  template:
+    metadata:
+      labels:
+        app: palworld
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: palworld
+          image: thijsvanloef/palworld-server-docker:v2.6.0
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: Asia/Tokyo
+            - name: PORT
+              value: "8211"
+            - name: PLAYERS
+              value: "16"
+            - name: SERVER_NAME
+              value: palworld
+            - name: MULTITHREADING
+              value: "true"
+            - name: COMMUNITY
+              value: "false"
+            - name: SERVER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: palworld-secret
+                  key: SERVER_PASSWORD
+          ports:
+            - name: game
+              containerPort: 8211
+              protocol: UDP
+          resources:
+            requests:
+              cpu: "2"
+              memory: 8Gi
+            limits:
+              memory: 16Gi
+          volumeMounts:
+            - name: data
+              mountPath: /palworld
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: palworld-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: palworld
+  namespace: palworld
+spec:
+  type: NodePort
+  selector:
+    app: palworld
+  ports:
+    - name: game
+      port: 8211
+      targetPort: game
+      protocol: UDP
+      nodePort: 30211

--- a/kubernetes/applications/palworld/palworld.yaml
+++ b/kubernetes/applications/palworld/palworld.yaml
@@ -29,6 +29,8 @@ spec:
       labels:
         app: palworld
     spec:
+      nodeSelector:
+        kubernetes.io/hostname: zen2
       securityContext:
         fsGroup: 1000
       containers:


### PR DESCRIPTION
## 概要

- パルワールド専用サーバーを Argo CD アプリケーションとして追加 (`kubernetes/applications/palworld/`)
- イメージ: `thijsvanloef/palworld-server-docker:v2.6.0`
- ストレージ: Longhorn PVC 20Gi (`/palworld`)
- リソース: requests cpu 2 / memory 8Gi、limits memory 16Gi
- コンピュート: `nodeSelector` で zen2 に固定
- 公開: NodePort (UDP 30211 → 8211)。さくらの VPS の固定 IP 宛に接続すると、kube-proxy が Tailscale 経由で zen2 上の Pod に転送する。UDP のため Cloudflare Tunnel は使用不可
- `SERVER_PASSWORD` は External Secrets 経由で GCP Secret Manager の `palworld-server-password` から取得

## マージ後の作業

- [ ] GCP Secret Manager にシークレット `palworld-server-password` を作成(未作成だと Pod が起動しません)
- [ ] さくらの VPS のパケットフィルタ / NixOS ファイアウォールで UDP 30211 の受信を許可

## テスト計画

- [ ] `kubectl apply --dry-run=client` で全マニフェストの検証済み
- [ ] Argo CD 同期後、Pod が zen2 で Running になることを確認
- [ ] さくらの VPS の固定 IP:30211 (UDP) にゲームクライアントから接続できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)