### PR TITLE
feat: OpenClaw に Gemini (Vertex) のフォールバックモデルを追加

### DIFF
--- a/kubernetes/applications/openclaw/configmap.yaml
+++ b/kubernetes/applications/openclaw/configmap.yaml
@@ -75,7 +75,8 @@ data:
       "agents": {
         "defaults": {
           "model": {
-            "primary": "anthropic-vertex/claude-sonnet-4-6"
+            "primary": "anthropic-vertex/claude-sonnet-4-6",
+            "fallbacks": ["google-vertex/gemini-2.5-pro"]
           }
         }
       },


### PR DESCRIPTION
## 概要

Claude のクォータ承認待ちの間も OpenClaw を稼働させるため、`google-vertex/gemini-2.5-pro` をフォールバックモデルに追加します。

- Vertex の Gemini は同じ ADC・同じ SA でそのまま呼び出せることを実 API で確認済み(`gemini-2.5-pro` / `gemini-2.5-flash` が応答)
- OpenClaw 組み込みの `google-vertex` プロバイダが ADC を自動検出するため、追加のシークレットや Terraform 変更は不要
- primary は `anthropic-vertex/claude-sonnet-4-6` のまま。Claude が 429 の間は自動で Gemini にフォールバックし、クォータが通れば自動的に Claude 優先へ戻ります
- ローカル Docker で検証済み: モデル解決(`fallback#1` 登録)と gateway 経由呼び出しが鍵署名段階まで到達

マージ後は `kubectl -n openclaw rollout restart deploy/openclaw` で反映します(こちらで実施します)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)