### PR TITLE
fix: move arc-infra docker cache from Longhorn to a zen2 hostPath

### DIFF
--- a/kubernetes/applications/arc-runners/arc-infra-values.yaml
+++ b/kubernetes/applications/arc-runners/arc-infra-values.yaml
@@ -63,8 +63,9 @@ template:
       - name: dind-externals
         emptyDir: {}
       - name: docker-data
-        persistentVolumeClaim:
-          claimName: arc-infra-docker
+        hostPath:
+          path: /var/lib/arc-infra-docker
+          type: DirectoryOrCreate
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup

--- a/kubernetes/applications/arc-runners/pvc.yaml
+++ b/kubernetes/applications/arc-runners/pvc.yaml
@@ -10,15 +10,3 @@ spec:
   resources:
     requests:
       storage: 50Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: arc-infra-docker
-  namespace: arc-runners
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 30Gi


### PR DESCRIPTION
## 概要

diff-preview が毎回 error になる問題の修正(3 つ目にして最後の障害)です。

## 原因

kind の etcd データは dind の `/var/lib/docker`(= Longhorn PVC)上にあり、etcd の fsync が Longhorn のデータパスを通ると並行 IO 下でタイムアウトします:

```
Command Output: Error from server: etcdserver: request timed out
```

アイドル状態での手動再現(同一イメージ・同一 dockerd)では 40 秒で Ready になることを確認済みで、レイテンシ起因で確定です。

## 変更内容

- dind の `/var/lib/docker` を Longhorn PVC → **zen2 の hostPath**(`/var/lib/arc-infra-docker`)に変更
  - runner は既に zen2 固定なので整合性の問題なし
  - イメージキャッシュ(~1.5GB)は引き続き永続、etcd はローカルディスクのレイテンシに
- 不要になった `arc-infra-docker` PVC を削除(Argo CD の prune で消えます)

## マージ後

初回はイメージの再 pull が入ります。以後の PR で diff-preview が通ることを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)