### PR TITLE
ci: install gh CLI on arc-infra runner for diff comments

### DIFF
--- a/.github/workflows/argocd-diff-preview.yaml
+++ b/.github/workflows/argocd-diff-preview.yaml
@@ -47,6 +47,10 @@ jobs:
             -e REPO=${{ github.repository }} \
             dagandersen/argocd-diff-preview:v0.2.11
 
+      # The arc runner image ships without the gh CLI
+      - name: Install gh CLI
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq gh
+
       - name: Post diff as comment
         run: |
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md --edit-last || \

--- a/kubernetes/applications/arc-runners/namespace.yaml
+++ b/kubernetes/applications/arc-runners/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: arc-runners
+  labels:
+    app.kubernetes.io/part-of: arc


### PR DESCRIPTION
## 概要

#177 後の diff-preview を生きた PR で end-to-end 検証したところ、kind + Argo CD + diff 生成まで成功し、最後のコメント投稿だけが `gh: command not found` で落ちました(ARC の runner イメージは hosted と違い gh CLI を含まない)。

## 変更内容

- diff コメント投稿の前に `gh` を apt でインストールするステップを追加
- 検証のための実変更として arc-runners namespace に `app.kubernetes.io/part-of` ラベルを追加

この PR の diff-preview check が green になれば ARC 移行は完了です。そのままマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)