### PR TITLE
Add beancount (fava) app with git-sync and Cloudflare Access

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -18,6 +18,8 @@ spec:
             namespace: argocd
           - name: bbs
             namespace: bbs
+          - name: beancount
+            namespace: beancount
           - name: blues
             namespace: blues
           - name: cdi

--- a/kubernetes/applications/beancount/beancount.yaml
+++ b/kubernetes/applications/beancount/beancount.yaml
@@ -1,0 +1,105 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: beancount-git-ssh
+  namespace: beancount
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: 1password-sdk
+    kind: ClusterSecretStore
+  target:
+    name: beancount-git-ssh
+  data:
+    - secretKey: id_ed25519
+      remoteRef:
+        key: beancount/git-ssh/id_ed25519
+    - secretKey: known_hosts
+      remoteRef:
+        key: beancount/git-ssh/known_hosts
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fava
+  namespace: beancount
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fava
+  template:
+    metadata:
+      labels:
+        app: fava
+    spec:
+      securityContext:
+        fsGroup: 65533 # git-sync runs as UID 65533; makes the SSH key group-readable
+      initContainers:
+        - name: git-sync
+          image: registry.k8s.io/git-sync/git-sync:v4.7.1
+          restartPolicy: Always
+          args:
+            - --repo=git@github.com:toof-jp/beancount-ledger.git
+            - --ref=main
+            - --period=60s
+            - --root=/data
+            - --link=current
+            - --ssh-key-file=/etc/git-secret/id_ed25519
+            - --ssh-known-hosts-file=/etc/git-secret/known_hosts
+          startupProbe:
+            exec:
+              command: ["test", "-e", "/data/current"]
+            periodSeconds: 5
+            failureThreshold: 60
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          volumeMounts:
+            - name: repo
+              mountPath: /data
+            - name: git-ssh
+              mountPath: /etc/git-secret
+              readOnly: true
+      containers:
+        - name: fava
+          image: yegle/fava:v1.30
+          env:
+            - name: BEANCOUNT_FILE
+              value: /data/current/ledger.beancount
+          ports:
+            - name: http
+              containerPort: 5000
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: repo
+              mountPath: /data
+              readOnly: true
+      volumes:
+        - name: repo
+          emptyDir: {}
+        - name: git-ssh
+          secret:
+            secretName: beancount-git-ssh
+            defaultMode: 0440
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fava
+  namespace: beancount
+spec:
+  selector:
+    app: fava
+  ports:
+    - name: http
+      port: 5000
+      targetPort: http

--- a/kubernetes/applications/beancount/ingress.yaml
+++ b/kubernetes/applications/beancount/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fava
+  namespace: beancount
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: beancount.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fava
+                port:
+                  number: 5000

--- a/kubernetes/applications/beancount/namespace.yaml
+++ b/kubernetes/applications/beancount/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: beancount

--- a/terraform/access.tf
+++ b/terraform/access.tf
@@ -7,6 +7,7 @@ locals {
     "longhorn",
     "grafana",
     "obsidian-gui",
+    "beancount",
   ]
 }
 


### PR DESCRIPTION
## Summary
- Add `kubernetes/applications/beancount/`: fava (`yegle/fava:v1.30`) serving `ledger.beancount`, with a git-sync (`v4.7.1`) native sidecar that pulls the private `toof-jp/beancount-ledger` repo every 60s via SSH
- SSH deploy key (read-only, already registered on the repo) is provisioned via ExternalSecret from 1Password (`infra` vault, item `beancount`, section `git-ssh`)
- Expose via `cloudflare-tunnel` Ingress at `beancount.toof.jp` and register in the ApplicationSet
- Add `beancount` to `zero_trust_apps` in `terraform/access.tf` for Cloudflare Access (GitHub IdP, toof only)

## Test plan
- [ ] `kubectl apply --dry-run=client` passes (verified locally)
- [ ] After merge: ArgoCD syncs `beancount` app, pod becomes Ready (git-sync clone succeeds)
- [ ] Terraform apply creates the Access application for `beancount.toof.jp`
- [ ] `https://beancount.toof.jp` prompts Cloudflare Access login and shows fava

🤖 Generated with [Claude Code](https://claude.com/claude-code)