### PR TITLE
Fix beancount fava startup failures

### DIFF
--- a/kubernetes/applications/beancount/beancount.yaml
+++ b/kubernetes/applications/beancount/beancount.yaml
@@ -10,6 +10,15 @@ spec:
     kind: ClusterSecretStore
   target:
     name: beancount-git-ssh
+    template:
+      engineVersion: v2
+      data:
+        # 1Password SDK strips the trailing newline; OpenSSH refuses a key
+        # without it ("error in libcrypto"), so re-append via block scalar.
+        id_ed25519: |
+          {{ .id_ed25519 }}
+        known_hosts: |
+          {{ .known_hosts }}
   data:
     - secretKey: id_ed25519
       remoteRef:
@@ -33,6 +42,9 @@ spec:
       labels:
         app: fava
     spec:
+      # Prevent the "fava" Service from injecting FAVA_PORT=tcp://... which
+      # collides with the env var the yegle/fava image uses as its port number.
+      enableServiceLinks: false
       securityContext:
         fsGroup: 65533 # git-sync runs as UID 65533; makes the SSH key group-readable
       initContainers:


### PR DESCRIPTION
## Summary
- Re-append the trailing newline to `id_ed25519`/`known_hosts` via an ExternalSecret v2 template — the 1Password SDK provider strips it, and OpenSSH rejects a private key without it (`Load key ...: error in libcrypto`)
- Set `enableServiceLinks: false` — the `fava` Service injected `FAVA_PORT=tcp://10.105.x.x:5000`, which the `yegle/fava` image reads as its listen port (`Error: Invalid value for '-p' / '--port'`)

Both failures observed live after #179 was deployed; the newline fix was already verified by patching the live Secret (git-sync then synced successfully).

## Test plan
- [ ] After merge: delete `secret/beancount-git-ssh` in ns `beancount` so the ExternalSecret (refreshPolicy: CreatedOnce) re-renders it with the template
- [ ] Pod becomes 2/2 Ready
- [ ] `https://beancount.toof.jp` shows fava behind Cloudflare Access

🤖 Generated with [Claude Code](https://claude.com/claude-code)