### PR TITLE
fix: skip argocd-diff-preview workflow for fork pull requests

### DIFF
--- a/.github/workflows/argocd-diff-preview.yaml
+++ b/.github/workflows/argocd-diff-preview.yaml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   diff-preview:
+    # This job runs on a self-hosted runner inside the cluster network, so it
+    # must never execute code from fork pull requests.
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: arc-infra
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add a fork guard (`if: github.event.pull_request.head.repo.fork == false`) to the `diff-preview` job

## Why
This is a public repository and the `argocd-diff-preview` workflow runs on a self-hosted runner (`arc-infra`) inside the cluster network. For `pull_request` events, GitHub executes the workflow **as modified in the PR head**, so a fork PR could rewrite the workflow and run arbitrary code on the self-hosted runner (which also mounts the node's Docker socket). The guard restricts the job to same-repo PRs.