### PR TITLE
fix: harden argocd-diff-preview workflow credentials and image pinning

### DIFF
--- a/.github/workflows/argocd-diff-preview.yaml
+++ b/.github/workflows/argocd-diff-preview.yaml
@@ -22,12 +22,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: pull-request
+          persist-credentials: false
 
       - name: Checkout main branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
           path: main
+          persist-credentials: false
 
       - name: Set Argo CD custom values
         run: |
@@ -48,7 +50,7 @@ jobs:
             -v $(pwd)/values.yaml:/argocd-config/values.yaml \
             -e TARGET_BRANCH=refs/pull/${{ github.event.number }}/merge \
             -e REPO=${{ github.repository }} \
-            dagandersen/argocd-diff-preview:v0.2.11
+            dagandersen/argocd-diff-preview:v0.2.11@sha256:2828dfafbee281436efbfcf0f39ce055351aea9159130c13d771688946406568
 
       # The arc runner image ships without the gh CLI
       - name: Install gh CLI


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to both `actions/checkout` steps so the `GITHUB_TOKEN` is not written into `.git/config` of the checkout directories, which are bind-mounted into the render container.
- Digest-pin the render image: `dagandersen/argocd-diff-preview:v0.2.11` → `dagandersen/argocd-diff-preview:v0.2.11@sha256:2828dfafbee281436efbfcf0f39ce055351aea9159130c13d771688946406568` (multi-arch index digest from Docker Hub API), so the image reference is immutable.

## Notes
- The `gh pr comment` step uses `env.GITHUB_TOKEN` explicitly, so disabling persisted credentials does not break commenting.
- The `docker.sock` mount and `--network=host` are intentionally kept: argocd-diff-preview requires a Docker daemon, and the risk is already mitigated by the merged fork guard (`if: github.event.pull_request.head.repo.fork == false`), so untrusted fork code never reaches this job.
- This workflow file is listed in its own `paths:` trigger, so this PR running the workflow itself is expected.