### PR TITLE
fix: terraform security hardening

### DIFF
--- a/terraform/access.tf
+++ b/terraform/access.tf
@@ -8,6 +8,7 @@ locals {
     "grafana",
     "obsidian-gui",
     "beancount",
+    "openclaw",
   ]
 }
 

--- a/terraform/github_actions.tf
+++ b/terraform/github_actions.tf
@@ -71,12 +71,6 @@ resource "google_secret_manager_secret_iam_member" "monitoring_function_deployer
   member    = "serviceAccount:${google_service_account.monitoring_function_deployer.email}"
 }
 
-resource "google_project_iam_member" "monitoring_function_deployer_sa_user" {
-  project = google_project.toof_infra.project_id
-  role    = "roles/iam.serviceAccountUser"
-  member  = "serviceAccount:${google_service_account.monitoring_function_deployer.email}"
-}
-
 resource "google_service_account_iam_member" "default_compute_act_as" {
   service_account_id = "projects/${google_project.toof_infra.project_id}/serviceAccounts/${google_project.toof_infra.number}-compute@developer.gserviceaccount.com"
   role               = "roles/iam.serviceAccountUser"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -106,8 +106,8 @@ data "aws_iam_policy_document" "terraform_management" {
       "s3:*"
     ]
     resources = [
-      "arn:aws:s3:::*",
-      "arn:aws:s3:::*/*"
+      "arn:aws:s3:::${aws_s3_bucket.remote_state.bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.remote_state.bucket}/*"
     ]
   }
 }

--- a/terraform/oci.tf
+++ b/terraform/oci.tf
@@ -58,19 +58,17 @@ resource "oci_core_default_security_list" "k8s" {
     protocol         = "all"
   }
 
-  ingress_security_rules {
-    protocol = "6"
-    source   = "0.0.0.0/0"
-
-    tcp_options {
-      min = 22
-      max = 22
-    }
-  }
+  # SSH is not exposed publicly; access is over Tailscale (same policy as
+  # vultr-vps, see vultr.tf).
 
   ingress_security_rules {
     protocol = "1"
     source   = "0.0.0.0/0"
+
+    icmp_options {
+      type = 3
+      code = 4
+    }
   }
 
   ingress_security_rules {


### PR DESCRIPTION
## Summary

Addresses four security findings in the Terraform code:

- **GCP (github_actions.tf):** Remove the project-wide `roles/iam.serviceAccountUser` binding for the monitoring-function-deployer SA. The narrowly-scoped per-SA binding (`default_compute_act_as` on the default compute SA) remains, along with the roles the deployer needs (run.developer, run.admin, cloudfunctions.developer, storage.objectAdmin, secretmanager.secretAccessor).
- **OCI (oci.tf):** Remove the TCP/22 ingress rule from the default security list (source 0.0.0.0/0). SSH access is over Tailscale per the documented design (see vultr.tf). Ports 80/443 and VCN-internal rules are kept. Public ICMP ingress is tightened to type 3, code 4 (fragmentation needed / PMTUD) only.
- **AWS (iam.tf):** Scope the `ManageS3BucketsAndObjects` statement from `s3:*` on all buckets to the remote-state bucket only (`arn:aws:s3:::toof-infra-terraform-remote-state` and `/*`).
- **Cloudflare (access.tf):** Add `openclaw` to the Zero Trust Access applications list.

## Checks

- `terraform fmt` run; `terraform validate` skipped (requires init/backend, no credentials available).
- No `terraform plan`/`apply` run.

## Note

After apply, SSH to the OCI instance is only reachable over Tailscale — verify Tailscale connectivity before applying.