### PR TITLE
fix: drop headlamp SA-token auto-login and arc-infra /lib/modules hostPath

### DIFF
--- a/kubernetes/applications/arc-runners/arc-infra-values.yaml
+++ b/kubernetes/applications/arc-runners/arc-infra-values.yaml
@@ -52,9 +52,6 @@ template:
             mountPath: /var/lib/docker
           - name: cgroup
             mountPath: /sys/fs/cgroup
-          - name: modules
-            mountPath: /lib/modules
-            readOnly: true
     volumes:
       - name: work
         emptyDir: {}
@@ -69,8 +66,4 @@ template:
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup
-          type: Directory
-      - name: modules
-        hostPath:
-          path: /lib/modules
           type: Directory

--- a/kubernetes/applications/headlamp.yaml
+++ b/kubernetes/applications/headlamp.yaml
@@ -15,8 +15,6 @@ spec:
       targetRevision: "0.43.0"
       helm:
         valuesObject:
-          config:
-            unsafeUseServiceAccountToken: true
           ingress:
             enabled: true
             ingressClassName: cloudflare-tunnel


### PR DESCRIPTION
## Summary
- **headlamp.yaml**: remove `unsafeUseServiceAccountToken: true`. It made the web UI auto-login with the pod's ServiceAccount token, which the chart binds to cluster-admin by default — so anyone past Cloudflare Access held single-factor cluster-admin. Users now log in with a token manually.
- **arc-infra-values.yaml**: remove the `/lib/modules` hostPath volume + mount from the dind sidecar. Stock `docker:dind` never modprobes; the mount only widened host attack surface (container could read host kernel modules, and combined with privileged it eased module-loading escapes).

## Kept deliberately (investigated via git history)
- `securityContext.privileged: true` on dind — required by docker:dind.
- `/sys/fs/cgroup` hostPath — added in 3fb7489 because kind nodes boot systemd inside dind and need the host cgroup2 hierarchy; without it cluster creation dies waiting for Multi-User System. **Residual risk**: rw access to the host cgroup hierarchy lets the (already privileged) container manage host cgroups; accepted because the container is privileged anyway and kind breaks without it.
- `/var/lib/arc-infra-docker` hostPath for `/var/lib/docker` — 1f783e6 moved this *off* a Longhorn PVC because kind's etcd fsyncs through the Longhorn data path timed out and killed every diff-preview cluster start. PVC was the broken state, so it stays a hostPath. **Residual risk**: rw hostPath into host disk; mitigated by `DirectoryOrCreate` scoping to a dedicated path and the runner being pinned to zen2.
- **arc-dotfiles-values.yaml**: no dind, no privileged, no hostPath — nothing to harden there.

## Validation
- `headlamp.yaml` parses via `kubectl apply --dry-run=client`.
- Both values files parse as YAML (ruby YAML).

## Note on /lib/modules
3fb7489's commit message cites the kind-in-Kubernetes reference config for this mount. That reference targets ensuring modules *can* be loaded on constrained nodes; kind only needs modules (e.g. `ip_vs`, br_netfilter) already loaded on the host, which zen2 provides. If kind ever fails on missing modules, load them on the host via systemd modules-load.d instead of mounting host /lib/modules into a privileged container.