### PR TITLE
fix: harden k8s manifests and repo gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 /node_modules
 kubernetes/applications/*/charts/
+
+.env
+.env.*
+!.env.template
+key.json
+credentials*.json
+*.pem
+*.tfstate*
+*.tfvars*

--- a/kubernetes/applications/kube-prometheus-stack.yaml
+++ b/kubernetes/applications/kube-prometheus-stack.yaml
@@ -44,6 +44,10 @@ spec:
             - operator: Exists
         grafana:
           nodeSelector: *zen2
+          admin:
+            existingSecret: grafana-admin-secret
+            userKey: admin-user
+            passwordKey: admin-password
           ingress:
             enabled: true
             ingressClassName: cloudflare-tunnel

--- a/kubernetes/applications/monitoring/grafana-admin-secret.yaml
+++ b/kubernetes/applications/monitoring/grafana-admin-secret.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-admin-external-secret
+  namespace: monitoring
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: grafana-admin-secret
+    template:
+      type: Opaque
+      data:
+        admin-user: admin
+        admin-password: "{{ .password }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: ClusterGenerator
+          name: password

--- a/kubernetes/applications/monitoring/otel-collector.yaml
+++ b/kubernetes/applications/monitoring/otel-collector.yaml
@@ -19,7 +19,7 @@ data:
 
     exporters:
       debug:
-        verbosity: detailed
+        verbosity: basic
       googlecloud:
         project: toof-infra
 

--- a/kubernetes/applications/shisha-log/db.yaml
+++ b/kubernetes/applications/shisha-log/db.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:18
+          image: postgres:18.4
           ports:
             - containerPort: 5432
               name: postgres

--- a/kubernetes/applications/shisha-log/migration.yaml
+++ b/kubernetes/applications/shisha-log/migration.yaml
@@ -126,15 +126,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: postgres:18
+          image: postgres:18.4
           command:
-            - psql
-          args:
-            - $(DATABASE_URL)
-            - -v
-            - ON_ERROR_STOP=1
-            - -f
-            - /sql/schema.sql
+            - sh
+            - -c
+            - psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /sql/schema.sql
           env:
             - name: PGCONNECT_TIMEOUT
               value: "10"

--- a/kubernetes/applications/shisha-log/shisha-log.yaml
+++ b/kubernetes/applications/shisha-log/shisha-log.yaml
@@ -27,7 +27,7 @@ spec:
             - name: TOKEN_DURATION
               value: 24h
             - name: ALLOWED_ORIGINS
-              value: http://localhost:5173,https://localhost:5173,https://shisha.toof.jp
+              value: https://shisha.toof.jp
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://otel-collector.monitoring.svc.cluster.local:4318
           envFrom:


### PR DESCRIPTION
## Summary
- **Root `.gitignore`**: ignore `.env`, `.env.*` (with `!.env.template` exception), `key.json`, `credentials*.json`, `*.pem`, `*.tfstate*`, `*.tfvars*` — docs instruct creating a GCP SA `key.json` and terraform uses `.env.template`, none of which were ignored at repo root.
- **Grafana admin password**: add `monitoring/grafana-admin-secret.yaml` ExternalSecret using the existing `password` ClusterGenerator (same pattern as immich/bbs), and set `grafana.admin.existingSecret`/`userKey`/`passwordKey` in kube-prometheus-stack values instead of the chart default `admin`/`prom-operator`.
- **otel-collector**: reduce debug exporter `verbosity` from `detailed` to `basic` so full telemetry payloads no longer flood pod logs.
- **shisha-log**: drop `http://localhost:5173`/`https://localhost:5173` from production `ALLOWED_ORIGINS`; pass `DATABASE_URL` to psql via env (`sh -c 'psql "$DATABASE_URL" ...'`) instead of argv where it was visible in /proc; pin `postgres:18` → `postgres:18.4` (latest 18.x on Docker Hub) in both `db.yaml` and `migration.yaml`.

All edited YAML validated with yamllint.