### PR TITLE
Migrate HCP Terraform to dynamic provider credentials for GCP and AWS

### DIFF
--- a/terraform/hcp_terraform.tf
+++ b/terraform/hcp_terraform.tf
@@ -1,17 +1,3 @@
-data "google_secret_manager_secret_version" "aws_access_key_id" {
-  project    = google_project.toof_infra.project_id
-  secret     = "aws_access_key_id"
-  version    = "latest"
-  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
-}
-
-data "google_secret_manager_secret_version" "aws_secret_access_key" {
-  project    = google_project.toof_infra.project_id
-  secret     = "aws_secret_access_key"
-  version    = "latest"
-  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
-}
-
 resource "tfe_organization" "infra" {
   name  = "toof-infra"
   email = var.tfe_email
@@ -37,10 +23,6 @@ resource "tfe_workspace_settings" "infra" {
 }
 
 locals {
-  aws_access_key_id_value     = data.google_secret_manager_secret_version.aws_access_key_id.secret_data
-  aws_secret_access_key_value = data.google_secret_manager_secret_version.aws_secret_access_key.secret_data
-  google_credentials_value    = replace(replace(base64decode(google_service_account_key.terraform_sa_key.private_key), "\r", ""), "\n", "")
-
   hcp_terraform_variables = {
     google_billing_account = {
       value     = var.google_billing_account
@@ -120,33 +102,30 @@ locals {
       # vultr_api_key above.
       hcl = false
     }
-    AWS_ACCESS_KEY_ID = {
-      value     = local.aws_access_key_id_value
-      sensitive = true
+    TFC_GCP_PROVIDER_AUTH = {
+      value     = "true"
+      sensitive = false
       category  = "env"
     }
-    AWS_SECRET_ACCESS_KEY = {
-      value     = local.aws_secret_access_key_value
-      sensitive = true
+    TFC_GCP_RUN_SERVICE_ACCOUNT_EMAIL = {
+      value     = google_service_account.terraform_sa.email
+      sensitive = false
       category  = "env"
     }
-    GOOGLE_CREDENTIALS = {
-      value     = local.google_credentials_value
-      sensitive = true
+    TFC_GCP_WORKLOAD_PROVIDER_NAME = {
+      value     = google_iam_workload_identity_pool_provider.hcp_terraform.name
+      sensitive = false
       category  = "env"
     }
-  }
-}
-
-resource "terraform_data" "validate_hcp_env_secrets" {
-  lifecycle {
-    precondition {
-      condition = alltrue([
-        local.aws_access_key_id_value != "",
-        local.aws_secret_access_key_value != "",
-        local.google_credentials_value != "",
-      ])
-      error_message = "Missing required secrets: ensure aws_access_key_id, aws_secret_access_key (GSM) and terraform_sa key (GOOGLE_CREDENTIALS) are populated."
+    TFC_AWS_PROVIDER_AUTH = {
+      value     = "true"
+      sensitive = false
+      category  = "env"
+    }
+    TFC_AWS_RUN_ROLE_ARN = {
+      value     = aws_iam_role.hcp_terraform.arn
+      sensitive = false
+      category  = "env"
     }
   }
 }

--- a/terraform/hcp_terraform_oidc.tf
+++ b/terraform/hcp_terraform_oidc.tf
@@ -1,0 +1,92 @@
+locals {
+  hcp_terraform_aws_sub = "organization:${tfe_organization.infra.name}:project:Default Project:workspace:${tfe_workspace.infra.name}:run_phase:*"
+}
+
+resource "google_iam_workload_identity_pool" "hcp_terraform" {
+  project                   = google_project.toof_infra.project_id
+  workload_identity_pool_id = "hcp-terraform"
+  display_name              = "HCP Terraform"
+  description               = "OIDC pool for HCP Terraform dynamic provider credentials"
+  depends_on                = [google_project_service.enabled["iam.googleapis.com"]]
+}
+
+resource "google_iam_workload_identity_pool_provider" "hcp_terraform" {
+  project                            = google_project.toof_infra.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.hcp_terraform.workload_identity_pool_id
+  workload_identity_pool_provider_id = "hcp-terraform"
+  display_name                       = "HCP Terraform"
+
+  attribute_mapping = {
+    "google.subject"                        = "assertion.sub"
+    "attribute.terraform_organization_name" = "assertion.terraform_organization_name"
+    "attribute.terraform_project_name"      = "assertion.terraform_project_name"
+    "attribute.terraform_workspace_name"    = "assertion.terraform_workspace_name"
+    "attribute.terraform_run_phase"         = "assertion.terraform_run_phase"
+  }
+
+  attribute_condition = "assertion.terraform_organization_name == \"${tfe_organization.infra.name}\" && assertion.terraform_workspace_name == \"${tfe_workspace.infra.name}\""
+
+  oidc {
+    issuer_uri = "https://app.terraform.io"
+  }
+}
+
+resource "google_service_account_iam_member" "terraform_sa_hcp_wiuser" {
+  service_account_id = google_service_account.terraform_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.hcp_terraform.name}/attribute.terraform_workspace_name/${tfe_workspace.infra.name}"
+}
+
+data "tls_certificate" "hcp_terraform" {
+  url = "https://app.terraform.io"
+}
+
+resource "aws_iam_openid_connect_provider" "hcp_terraform" {
+  url             = "https://app.terraform.io"
+  client_id_list  = ["aws.workload.identity"]
+  thumbprint_list = [data.tls_certificate.hcp_terraform.certificates[0].sha1_fingerprint]
+
+  tags = {
+    ManagedBy = "terraform"
+  }
+}
+
+data "aws_iam_policy_document" "hcp_terraform_trust" {
+  statement {
+    sid    = "AllowHCPTerraformAssumeRoleWithWebIdentity"
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.hcp_terraform.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "app.terraform.io:aud"
+      values   = ["aws.workload.identity"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "app.terraform.io:sub"
+      values   = [local.hcp_terraform_aws_sub]
+    }
+  }
+}
+
+resource "aws_iam_role" "hcp_terraform" {
+  name               = "hcp-terraform-run"
+  assume_role_policy = data.aws_iam_policy_document.hcp_terraform_trust.json
+
+  tags = {
+    ManagedBy = "terraform"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "hcp_terraform_assume_role" {
+  role       = aws_iam_role.hcp_terraform.name
+  policy_arn = aws_iam_policy.hcp_terraform_assume_role.arn
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,8 +1,9 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  terraform_user_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/terraform"
-  terraform_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/terraform-management"
+  terraform_user_arn     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/terraform"
+  terraform_role_arn     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/terraform-management"
+  hcp_terraform_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/hcp-terraform-run"
   terraform_policy_arns = [
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/TerraformManagementPolicy",
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/TerraformUserAssumeRole",
@@ -42,7 +43,10 @@ data "aws_iam_policy_document" "terraform_management" {
       "iam:UpdateRole",
       "iam:UpdateRoleDescription",
     ]
-    resources = [local.terraform_role_arn]
+    resources = [
+      local.terraform_role_arn,
+      local.hcp_terraform_role_arn,
+    ]
   }
 
   statement {
@@ -74,6 +78,7 @@ data "aws_iam_policy_document" "terraform_management" {
     resources = [
       local.terraform_user_arn,
       local.terraform_role_arn,
+      local.hcp_terraform_role_arn,
     ]
     condition {
       test     = "ArnEquals"
@@ -112,14 +117,6 @@ data "aws_iam_policy_document" "terraform_management" {
   }
 }
 
-resource "aws_iam_user" "terraform" {
-  name = "terraform"
-
-  tags = {
-    ManagedBy = "terraform"
-  }
-}
-
 resource "aws_iam_policy" "terraform_management" {
   name        = "TerraformManagementPolicy"
   description = "Allows Terraform to manage IAM and S3 resources."
@@ -128,12 +125,12 @@ resource "aws_iam_policy" "terraform_management" {
 
 data "aws_iam_policy_document" "terraform_role_trust" {
   statement {
-    sid    = "AllowTerraformUserAssumeRole"
+    sid    = "AllowHCPTerraformRunRoleAssumeRole"
     effect = "Allow"
 
     principals {
       type        = "AWS"
-      identifiers = [aws_iam_user.terraform.arn]
+      identifiers = [aws_iam_role.hcp_terraform.arn]
     }
 
     actions = ["sts:AssumeRole"]
@@ -154,7 +151,7 @@ resource "aws_iam_role_policy_attachment" "terraform_management" {
   policy_arn = aws_iam_policy.terraform_management.arn
 }
 
-data "aws_iam_policy_document" "terraform_user_assume_role" {
+data "aws_iam_policy_document" "hcp_terraform_assume_role" {
   statement {
     sid     = "AllowAssumeTerraformManagementRole"
     actions = ["sts:AssumeRole"]
@@ -164,13 +161,13 @@ data "aws_iam_policy_document" "terraform_user_assume_role" {
   }
 }
 
-resource "aws_iam_policy" "terraform_user_assume_role" {
+resource "aws_iam_policy" "hcp_terraform_assume_role" {
   name        = "TerraformUserAssumeRole"
-  description = "Allows the terraform IAM user to assume the terraform-management role."
-  policy      = data.aws_iam_policy_document.terraform_user_assume_role.json
+  description = "Allows the HCP Terraform run role to assume the terraform-management role."
+  policy      = data.aws_iam_policy_document.hcp_terraform_assume_role.json
 }
 
-resource "aws_iam_user_policy_attachment" "terraform_assume_role" {
-  user       = aws_iam_user.terraform.name
-  policy_arn = aws_iam_policy.terraform_user_assume_role.arn
+moved {
+  from = aws_iam_policy.terraform_user_assume_role
+  to   = aws_iam_policy.hcp_terraform_assume_role
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -43,6 +43,11 @@ terraform {
     terraform = {
       source = "terraform.io/builtin/terraform"
     }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4"
+    }
   }
 
   cloud {

--- a/terraform/service_account.tf
+++ b/terraform/service_account.tf
@@ -48,10 +48,6 @@ resource "google_service_account_key" "otel_sa_key" {
   service_account_id = google_service_account.otel_sa.name
 }
 
-resource "google_service_account_key" "terraform_sa_key" {
-  service_account_id = google_service_account.terraform_sa.name
-}
-
 resource "google_secret_manager_secret" "otel_sa_secret" {
   secret_id = "otel-collector-sa-key"
   replication {
@@ -63,19 +59,6 @@ resource "google_secret_manager_secret" "otel_sa_secret" {
 resource "google_secret_manager_secret_version" "otel_sa_secret_ver" {
   secret      = google_secret_manager_secret.otel_sa_secret.id
   secret_data = google_service_account_key.otel_sa_key.private_key
-}
-
-resource "google_secret_manager_secret" "terraform_sa_secret" {
-  secret_id = "terraform-service-account-key"
-  replication {
-    auto {}
-  }
-  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
-}
-
-resource "google_secret_manager_secret_version" "terraform_sa_secret_ver" {
-  secret      = google_secret_manager_secret.terraform_sa_secret.id
-  secret_data = google_service_account_key.terraform_sa_key.private_key
 }
 
 resource "google_service_account" "openclaw_vertex_sa" {


### PR DESCRIPTION
## Summary

Replaces the long-lived cloud credentials injected into the HCP Terraform workspace (`GOOGLE_CREDENTIALS`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) with [dynamic provider credentials](https://developer.hashicorp.com/terraform/cloud-docs/dynamic-provider-credentials) for both GCP and AWS.

### GCP
- New dedicated Workload Identity Pool + provider `hcp-terraform` (issuer `https://app.terraform.io`) in `terraform/hcp_terraform_oidc.tf` — separate from the GitHub Actions pool in `github_actions.tf`.
- `attribute_condition` restricts tokens to `terraform_organization_name == "toof-infra" && terraform_workspace_name == "toof-infra"`.
- `roles/iam.workloadIdentityUser` binding on the `terraform` SA scoped to the workspace-level principalSet (`attribute.terraform_workspace_name/toof-infra`).
- Workspace env vars: `TFC_GCP_PROVIDER_AUTH`, `TFC_GCP_RUN_SERVICE_ACCOUNT_EMAIL`, `TFC_GCP_WORKLOAD_PROVIDER_NAME` (non-sensitive).

### AWS
- `aws_iam_openid_connect_provider` for `https://app.terraform.io` (thumbprint via `tls_certificate` data source, audience `aws.workload.identity`).
- New role `hcp-terraform-run` with a trust policy conditioned on `aud == aws.workload.identity` (StringEquals) and `sub == organization:toof-infra:project:Default Project:workspace:toof-infra:run_phase:*` (StringLike). The workspace is in the org's default project ("Default Project") since no `tfe_project` is configured — please sanity-check the project name in the HCP UI before applying.
- The new role gets the same attachment the IAM user had (`TerraformUserAssumeRole` → `sts:AssumeRole` on `terraform-management`), and `terraform-management`'s trust policy now allows the new role instead of the user. The AWS provider's existing `assume_role` to `terraform-management` is unchanged, so role chaining works identically for HCP runs and local CLI usage.
- Workspace env vars: `TFC_AWS_PROVIDER_AUTH`, `TFC_AWS_RUN_ROLE_ARN` (non-sensitive).

## Removed resources
- `google_service_account_key.terraform_sa_key` (admin-grade SA key)
- `google_secret_manager_secret.terraform_sa_secret` + version (`terraform-service-account-key`) — sole consumer was the workspace
- `aws_iam_user.terraform` + `aws_iam_user_policy_attachment.terraform_assume_role` (no other references; the access key itself was created out-of-band, see rollout)
- tfe_variables `GOOGLE_CREDENTIALS`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
- GSM data sources for `aws_access_key_id` / `aws_secret_access_key` and the `validate_hcp_env_secrets` precondition. NOTE: those GSM secrets are hand-seeded (not Terraform-managed) — delete them manually in GCP after rollout.
- No `aws_iam_access_key` resource existed in state to remove.

## Kept keys (need separate migration)
- `google_service_account_key.otel_sa_key` and `google_service_account_key.openclaw_vertex_sa_key` — consumed by the k8s cluster via ExternalSecrets (`otel-collector-sa-key`, `openclaw-vertex-sa-key`), NOT by the HCP workspace. These should migrate to GKE Workload Identity in a separate change.

## Intentional leftovers (follow-up PR)
- `ManageTerraformUser` statement and the user ARN in `AttachManagedTerraformPolicies` remain in `TerraformManagementPolicy`: the apply that destroys `aws_iam_user.terraform` still needs `iam:DeleteUser`/`iam:DetachUserPolicy` on that ARN, and the policy update vs. user destroy are unordered in the graph. Remove them after the user is gone.
- AWS policy keeps the literal name `TerraformUserAssumeRole` (Terraform resource renamed to `hcp_terraform_assume_role` with a `moved` block). Renaming the AWS-side name forces destroy+create with a self-management ordering hazard; do it in a follow-up.

## Rollout (IMPORTANT — lockout risk)

After apply, the old keys are destroyed and the workspace can ONLY authenticate via dynamic credentials. If anything is misconfigured the pipeline locks itself out.

1. Merge this PR but DO NOT rely on the auto-queued VCS run yet.
2. Apply from a local CLI with the existing credentials first (`terraform apply` in `terraform/`). Expected hiccup: destroying `aws_iam_user.terraform` will fail with `DeleteConflict` because its access key was created out-of-band and still exists. Delete the access key manually in the AWS console (this permanently revokes the old credential), then re-run to finish the user destroy. Keep AWS console (root/admin) access open as break-glass.
3. In HCP Terraform, queue a **speculative plan** and verify it succeeds using only dynamic credentials (no `GOOGLE_CREDENTIALS`/AWS keys present).
4. Only then rely on normal VCS-driven runs.
5. Manually delete the hand-seeded GSM secrets `aws_access_key_id` / `aws_secret_access_key`.

## State hygiene

Terraform state (and historical state versions in HCP) still contains the old key material (SA private key JSON, AWS secret key). Since these were real credentials, treat them as exposed: the AWS key is revoked in step 2; rotate/revoke anything else that was a live credential. Consider scrubbing old state versions in HCP Terraform.

## Notes
- Role chaining (`hcp-terraform-run` → `terraform-management`) caps AWS sessions at 1 hour; applies here are far shorter.
- `terraform fmt` run; `terraform validate` passes (init without backend).