### PR TITLE
Add restricted toof-infra AppProject and refresh ExternalSecrets hourly

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -57,7 +57,7 @@ spec:
       name: "{{name}}"
       namespace: argocd
     spec:
-      project: default
+      project: toof-infra
       source:
         repoURL: https://github.com/toof-jp/infra
         targetRevision: HEAD

--- a/kubernetes/applications/arc-runners/external-secret.yaml
+++ b/kubernetes/applications/arc-runners/external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: arc-github-app-external-secret
   namespace: arc-runners
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/bbs/external-secret.yaml
+++ b/kubernetes/applications/bbs/external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fetch-post-discord-bot-external-secret
   namespace: bbs
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore
@@ -22,7 +22,7 @@ metadata:
   name: search-post-discord-bot-external-secret
   namespace: bbs
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore
@@ -39,7 +39,7 @@ metadata:
   name: discord-webhook-external-secret
   namespace: bbs
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore
@@ -62,7 +62,7 @@ metadata:
   name: postgres-external-secret
   namespace: bbs
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore
@@ -89,7 +89,7 @@ metadata:
   name: search-crawler-external-secret
   namespace: bbs
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore
@@ -115,7 +115,7 @@ metadata:
   name: mydns-jp-updater-secret
   namespace: bbs
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: 1password-sdk
     kind: ClusterSecretStore

--- a/kubernetes/applications/beancount/beancount.yaml
+++ b/kubernetes/applications/beancount/beancount.yaml
@@ -4,7 +4,7 @@ metadata:
   name: beancount-git-ssh
   namespace: beancount
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: 1password-sdk
     kind: ClusterSecretStore

--- a/kubernetes/applications/cloudflare-external-secret/external-secret.yaml
+++ b/kubernetes/applications/cloudflare-external-secret/external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cloudflare-external-secret
   namespace: cloudflare
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/cloudflare-tunnel-ingress-controller.yaml
+++ b/kubernetes/applications/cloudflare-tunnel-ingress-controller.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cloudflare-tunnel-ingress-controller
   namespace: argocd
 spec:
-  project: default
+  project: toof-infra
   source:
     repoURL: https://helm.strrl.dev
     chart: cloudflare-tunnel-ingress-controller

--- a/kubernetes/applications/dev-vm/ghcr-auth.yaml
+++ b/kubernetes/applications/dev-vm/ghcr-auth.yaml
@@ -13,7 +13,7 @@ metadata:
   name: ghcr-auth
   namespace: dev-vm
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/external-secrets/cluster-secret-store.yaml
+++ b/kubernetes/applications/external-secrets/cluster-secret-store.yaml
@@ -34,7 +34,7 @@ metadata:
   name: 1password-service-account-external-secret
   namespace: external-secrets
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/headlamp.yaml
+++ b/kubernetes/applications/headlamp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: headlamp
   namespace: argocd
 spec:
-  project: default
+  project: toof-infra
   sources:
     - repoURL: https://github.com/toof-jp/infra
       targetRevision: HEAD

--- a/kubernetes/applications/healthcheck/healthcheck.yaml
+++ b/kubernetes/applications/healthcheck/healthcheck.yaml
@@ -36,7 +36,7 @@ metadata:
   name: healthcheck-external-secret
   namespace: healthcheck
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/immich-mcp/ghcr-auth.yaml
+++ b/kubernetes/applications/immich-mcp/ghcr-auth.yaml
@@ -13,7 +13,7 @@ metadata:
   name: ghcr-auth
   namespace: immich-mcp
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/immich-mcp/immich-mcp.yaml
+++ b/kubernetes/applications/immich-mcp/immich-mcp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: immich-mcp
   namespace: immich-mcp
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/immich.yaml
+++ b/kubernetes/applications/immich.yaml
@@ -5,7 +5,7 @@ metadata:
   name: immich
   namespace: argocd
 spec:
-  project: default
+  project: toof-infra
   syncPolicy:
     automated:
       prune: true

--- a/kubernetes/applications/immich/external-secret.yaml
+++ b/kubernetes/applications/immich/external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: postgres-external-secret
   namespace: immich
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/kube-prometheus-stack.yaml
+++ b/kubernetes/applications/kube-prometheus-stack.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kube-prometheus-stack
   namespace: argocd
 spec:
-  project: default
+  project: toof-infra
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
     chart: kube-prometheus-stack

--- a/kubernetes/applications/longhorn.yaml
+++ b/kubernetes/applications/longhorn.yaml
@@ -5,7 +5,7 @@ metadata:
   name: longhorn
   namespace: argocd
 spec:
-  project: default
+  project: toof-infra
   source:
     repoURL: https://charts.longhorn.io/
     chart: longhorn

--- a/kubernetes/applications/mcp-gate/immich.yaml
+++ b/kubernetes/applications/mcp-gate/immich.yaml
@@ -5,7 +5,7 @@ metadata:
   name: mcp-gate-immich
   namespace: mcp-gate
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: 1password-sdk
     kind: ClusterSecretStore

--- a/kubernetes/applications/mcp-gate/mcp-gate.yaml
+++ b/kubernetes/applications/mcp-gate/mcp-gate.yaml
@@ -5,7 +5,7 @@ metadata:
   name: mcp-gate-obsidian
   namespace: mcp-gate
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: 1password-sdk
     kind: ClusterSecretStore

--- a/kubernetes/applications/metrics-server.yaml
+++ b/kubernetes/applications/metrics-server.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: argocd
 spec:
-  project: default
+  project: toof-infra
   source:
     repoURL: https://kubernetes-sigs.github.io/metrics-server/
     chart: metrics-server

--- a/kubernetes/applications/monitoring/otel-collector.yaml
+++ b/kubernetes/applications/monitoring/otel-collector.yaml
@@ -107,7 +107,7 @@ metadata:
   name: otel-collector-sa-key-external-secret
   namespace: monitoring
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/npm-stats/cronjob.yaml
+++ b/kubernetes/applications/npm-stats/cronjob.yaml
@@ -27,7 +27,7 @@ metadata:
   name: npm-stats-secret
   namespace: npm-stats
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/obsidian-msp/obsidian-msp.yaml
+++ b/kubernetes/applications/obsidian-msp/obsidian-msp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: obsidian-msp-git-sync
   namespace: obsidian-msp
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/obsidian/obsidian.yaml
+++ b/kubernetes/applications/obsidian/obsidian.yaml
@@ -5,7 +5,7 @@ metadata:
   name: obsidian-git-ssh
   namespace: obsidian
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: 1password-sdk
     kind: ClusterSecretStore

--- a/kubernetes/applications/openclaw/external-secret.yaml
+++ b/kubernetes/applications/openclaw/external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openclaw-external-secret
   namespace: openclaw
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore
@@ -22,7 +22,7 @@ metadata:
   name: openclaw-vertex-sa-key-external-secret
   namespace: openclaw
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore
@@ -40,7 +40,7 @@ metadata:
   name: openclaw-gateway-token-external-secret
   namespace: openclaw
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/palworld/external-secret.yaml
+++ b/kubernetes/applications/palworld/external-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: palworld-external-secret
   namespace: palworld
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/project.yaml
+++ b/kubernetes/applications/project.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: toof-infra
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://github.com/toof-jp/infra
+    - https://github.com/toof-jp/infra.git
+    - https://charts.external-secrets.io
+    - https://charts.longhorn.io/
+    - https://helm.strrl.dev
+    - https://immich-app.github.io/immich-charts
+    - https://kubernetes-sigs.github.io/headlamp/
+    - https://kubernetes-sigs.github.io/metrics-server/
+    - https://prometheus-community.github.io/helm-charts
+    - oci://ghcr.io/actions/actions-runner-controller-charts
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: "*"
+  clusterResourceWhitelist:
+    - group: ""
+      kind: Namespace
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: external-secrets.io
+      kind: ClusterSecretStore
+    - group: generators.external-secrets.io
+      kind: ClusterGenerator
+    - group: cdi.kubevirt.io
+      kind: CDI
+    - group: networking.k8s.io
+      kind: IngressClass
+    - group: scheduling.k8s.io
+      kind: PriorityClass
+    - group: apiregistration.k8s.io
+      kind: APIService
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration

--- a/kubernetes/applications/shisha-log/db.yaml
+++ b/kubernetes/applications/shisha-log/db.yaml
@@ -67,7 +67,7 @@ metadata:
   name: postgres-external-secret
   namespace: shisha-log
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/shisha-log/postgrest.yaml
+++ b/kubernetes/applications/shisha-log/postgrest.yaml
@@ -76,7 +76,7 @@ metadata:
   name: postgrest-external-secret
   namespace: shisha-log
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore

--- a/kubernetes/applications/shisha-log/shisha-log.yaml
+++ b/kubernetes/applications/shisha-log/shisha-log.yaml
@@ -40,7 +40,7 @@ metadata:
   name: shisha-log-external-secret
   namespace: shisha-log
 spec:
-  refreshPolicy: CreatedOnce
+  refreshInterval: 1h
   secretStoreRef:
     name: gcp-secret-manager
     kind: ClusterSecretStore


### PR DESCRIPTION
## Summary

- Add a restricted ArgoCD AppProject `toof-infra` (`kubernetes/applications/project.yaml`) and move every Application (ApplicationSet template + the standalone apps: longhorn, metrics-server, kube-prometheus-stack, immich, headlamp, cloudflare-tunnel-ingress-controller) off the unrestricted `default` project.
- Replace `refreshPolicy: CreatedOnce` with `refreshInterval: 1h` on all 28 ExternalSecrets so secrets are re-fetched periodically instead of only at creation (ESO v1 / chart 2.8.0 semantics; validated with server-side dry-run against the installed CRDs).

## AppProject details

- `sourceRepos` (exact match against all `repoURL:`/helm sources in the repo + live cluster audit):
  - `https://github.com/toof-jp/infra` (+ `.git` variant defensively)
  - `https://charts.longhorn.io/`, `https://kubernetes-sigs.github.io/metrics-server/`, `https://kubernetes-sigs.github.io/headlamp/`, `https://immich-app.github.io/immich-charts`, `https://prometheus-community.github.io/helm-charts`, `https://helm.strrl.dev`
  - `https://charts.external-secrets.io` and `oci://ghcr.io/actions/actions-runner-controller-charts` (kustomize `helmCharts`)
- `destinations`: only `https://kubernetes.default.svc` with `namespace: "*"` (apps legitimately deploy to many namespaces; pinning the server blocks deployment to arbitrary external clusters).
- `clusterResourceWhitelist`: `Namespace`, `CustomResourceDefinition`, `ClusterRole`, `ClusterRoleBinding`, `ClusterSecretStore`, `ClusterGenerator` (as found in the repo), **plus** `CDI`, `IngressClass`, `PriorityClass`, `APIService`, `MutatingWebhookConfiguration`, `ValidatingWebhookConfiguration`. The extra kinds came from auditing the live cluster (`status.resources` of every Application); without them, existing chart syncs (metrics-server, kube-prometheus-stack, external-secrets webhook, longhorn/kubevirt priority classes, cloudflare-tunnel IngressClass, cdi CR) would break.
- `namespaceResourceBlacklist` / `orphanedResources`: defaults (unchanged).

## Deliberations

- **`app-of-apps` intentionally stays in the `default` project** (the only remaining `project: default`). It bootstraps the AppProject itself (`project.yaml` lives in its sync path `kubernetes/applications/`), so a restricted `argocd` app managing the project would deadlock on first sync (the ApplicationSet switches `argocd` to `toof-infra`, which can't sync until the project exists). Managing AppProjects from the `default` project is also the standard ArgoCD pattern, and `app-of-apps`' own spec is not GitOps-managed anyway (its manifest is outside its own sync path).
- A restricted AppProject does not fully stop a repo pusher from exfiltrating secrets (they could edit the project too), but it turns project/destination/source policy into a single reviewable checkpoint and makes ArgoCD reject out-of-policy Applications.
- Rollout note: app-of-apps will create the `toof-infra` project in the same sync that flips the ApplicationSet template; brief "project does not exist" errors on generated apps resolve on retry once the project exists.

## Validation

- `prettier --check` passes (also YAML-parses every file); kubeconform CI runs on the PR.
- `kubectl apply --dry-run=server` passed for the AppProject and every changed ExternalSecret against the cluster's installed CRDs.
- Grep: no `refreshPolicy:` remains; the only `project: default` left is `app-of-apps.yaml` (deliberate, see above).