### PR TITLE
feat: add apple-health ingester, InfluxDB, and MCP server

### DIFF
--- a/kubernetes/applications/apple-health-mcp/apple-health-mcp.yaml
+++ b/kubernetes/applications/apple-health-mcp/apple-health-mcp.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: apple-health-mcp
+  namespace: apple-health-mcp
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: apple-health-mcp-secret
+  data:
+    - secretKey: INFLUXDB_TOKEN
+      remoteRef:
+        key: apple-health-influxdb-token
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apple-health-mcp-config
+  namespace: apple-health-mcp
+data:
+  INFLUXDB_URL: http://influxdb.apple-health.svc.cluster.local:8086
+  INFLUXDB_ORG: apple-health
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: apple-health-mcp
+  namespace: apple-health-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apple-health-mcp
+  template:
+    metadata:
+      labels:
+        app: apple-health-mcp
+    spec:
+      containers:
+        - name: influxdb-mcp-server
+          image: node:24-alpine
+          command:
+            - sh
+            - -c
+          args:
+            - exec npx --yes influxdb-mcp-server@0.2.0 --http 3000
+          ports:
+            - name: http
+              containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: apple-health-mcp-config
+            - secretRef:
+                name: apple-health-mcp-secret
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: apple-health-mcp
+  namespace: apple-health-mcp
+spec:
+  selector:
+    app: apple-health-mcp
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: apple-health-mcp
+  namespace: apple-health-mcp
+spec:
+  podSelector:
+    matchLabels:
+      app: apple-health-mcp
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-gate
+          podSelector:
+            matchLabels:
+              app: mcp-gate-apple-health
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: apple-health
+      ports:
+        - protocol: TCP
+          port: 8086
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/kubernetes/applications/apple-health-mcp/namespace.yaml
+++ b/kubernetes/applications/apple-health-mcp/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apple-health-mcp

--- a/kubernetes/applications/apple-health/influxdb.yaml
+++ b/kubernetes/applications/apple-health/influxdb.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: influxdb
+  namespace: apple-health
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: influxdb-secret
+  data:
+    - secretKey: DOCKER_INFLUXDB_INIT_PASSWORD
+      remoteRef:
+        key: apple-health-influxdb-password
+    - secretKey: DOCKER_INFLUXDB_INIT_ADMIN_TOKEN
+      remoteRef:
+        key: apple-health-influxdb-token
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: influxdb-config
+  namespace: apple-health
+data:
+  DOCKER_INFLUXDB_INIT_MODE: setup
+  DOCKER_INFLUXDB_INIT_USERNAME: admin
+  DOCKER_INFLUXDB_INIT_ORG: apple-health
+  DOCKER_INFLUXDB_INIT_BUCKET: apple-health
+  INFLUXD_REPORTING_DISABLED: "true"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: influxdb
+  namespace: apple-health
+spec:
+  serviceName: influxdb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: influxdb
+  template:
+    metadata:
+      labels:
+        app: influxdb
+    spec:
+      containers:
+        - name: influxdb
+          image: influxdb:2.7.12
+          ports:
+            - name: http
+              containerPort: 8086
+          envFrom:
+            - configMapRef:
+                name: influxdb-config
+            - secretRef:
+                name: influxdb-secret
+          volumeMounts:
+            - name: influxdb-data
+              mountPath: /var/lib/influxdb2
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: influxdb-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: influxdb
+  namespace: apple-health
+spec:
+  selector:
+    app: influxdb
+  ports:
+    - name: http
+      port: 8086
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: influxdb
+  namespace: apple-health
+spec:
+  podSelector:
+    matchLabels:
+      app: influxdb
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: apple-health-ingester
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: apple-health-mcp
+          podSelector:
+            matchLabels:
+              app: apple-health-mcp
+      ports:
+        - protocol: TCP
+          port: 8086
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/kubernetes/applications/apple-health/ingester.yaml
+++ b/kubernetes/applications/apple-health/ingester.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: apple-health-ingester
+  namespace: apple-health
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: apple-health-ingester-secret
+  data:
+    - secretKey: INFLUXDB_AUTH_TOKEN
+      remoteRef:
+        key: apple-health-influxdb-token
+    - secretKey: HTTP_AUTH_TOKEN
+      remoteRef:
+        key: apple-health-ingester-token
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: apple-health-ingester
+  namespace: apple-health
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apple-health-ingester
+  template:
+    metadata:
+      labels:
+        app: apple-health-ingester
+    spec:
+      containers:
+        - name: apple-health-ingester
+          image: irvinlim/apple-health-ingester:v0.5.0
+          args:
+            - --backend.influxdb
+            - --http.listenAddr=:8080
+            - --http.authToken=$(HTTP_AUTH_TOKEN)
+            - --influxdb.serverURL=http://influxdb.apple-health.svc.cluster.local:8086
+            - --influxdb.authToken=$(INFLUXDB_AUTH_TOKEN)
+            - --influxdb.orgName=apple-health
+            - --influxdb.metricsBucketName=apple-health
+            - --influxdb.workoutsBucketName=apple-health
+          env:
+            - name: HTTP_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: apple-health-ingester-secret
+                  key: HTTP_AUTH_TOKEN
+            - name: INFLUXDB_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: apple-health-ingester-secret
+                  key: INFLUXDB_AUTH_TOKEN
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: apple-health-ingester
+  namespace: apple-health
+spec:
+  selector:
+    app: apple-health-ingester
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: apple-health-ingester
+  namespace: apple-health
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: apple-health-ingest.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: apple-health-ingester
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: apple-health-ingester
+  namespace: apple-health
+spec:
+  podSelector:
+    matchLabels:
+      app: apple-health-ingester
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: influxdb
+      ports:
+        - protocol: TCP
+          port: 8086
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/kubernetes/applications/apple-health/namespace.yaml
+++ b/kubernetes/applications/apple-health/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apple-health

--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -8,6 +8,10 @@ spec:
   generators:
     - list:
         elements:
+          - name: apple-health
+            namespace: apple-health
+          - name: apple-health-mcp
+            namespace: apple-health-mcp
           - name: archiveteam-warrior
             namespace: archiveteam-warrior
           - name: arc-runners

--- a/kubernetes/applications/mcp-gate/apple-health.yaml
+++ b/kubernetes/applications/mcp-gate/apple-health.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mcp-gate-apple-health
+  namespace: mcp-gate
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: 1password-sdk
+    kind: ClusterSecretStore
+  target:
+    name: mcp-gate-apple-health-secret
+  data:
+    - secretKey: AUTHORIZATION_SERVER
+      remoteRef:
+        key: mcp-gate/apple-health/authorization-server
+    - secretKey: JWKS_URI
+      remoteRef:
+        key: mcp-gate/apple-health/jwks-uri
+    - secretKey: EXPECTED_ISSUER
+      remoteRef:
+        key: mcp-gate/apple-health/expected-issuer
+    - secretKey: EXPECTED_AUDIENCE
+      remoteRef:
+        key: mcp-gate/apple-health/expected-audience
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-gate-apple-health-config
+  namespace: mcp-gate
+data:
+  LISTEN_ADDR: 0.0.0.0:8080
+  RESOURCE_URI: https://apple-health-mcp.toof.jp/
+  UPSTREAM_URL: http://apple-health-mcp.apple-health-mcp.svc.cluster.local:3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-gate-apple-health
+  namespace: mcp-gate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-gate-apple-health
+  template:
+    metadata:
+      labels:
+        app: mcp-gate-apple-health
+    spec:
+      containers:
+        - name: mcp-gate
+          image: cpremus/mcp-gate:0.16.28
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: mcp-gate-apple-health-config
+            - secretRef:
+                name: mcp-gate-apple-health-secret
+          readinessProbe:
+            httpGet:
+              path: /.well-known/oauth-protected-resource
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /.well-known/oauth-protected-resource
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-gate-apple-health
+  namespace: mcp-gate
+spec:
+  selector:
+    app: mcp-gate-apple-health
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-gate-apple-health
+  namespace: mcp-gate
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: apple-health-mcp.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-gate-apple-health
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-gate-apple-health
+  namespace: mcp-gate
+spec:
+  podSelector:
+    matchLabels:
+      app: mcp-gate-apple-health
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: apple-health-mcp
+          podSelector:
+            matchLabels:
+              app: apple-health-mcp
+      ports:
+        - protocol: TCP
+          port: 3000
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION
## 概要

Apple Health のデータを [Health Auto Export](https://www.healthyapps.dev/) (iOS アプリ) から受信し、InfluxDB に蓄積して MCP 経由で参照できるようにします。

- **apple-health namespace**
  - [irvinlim/apple-health-ingester](https://github.com/irvinlim/apple-health-ingester) `v0.5.0` — Health Auto Export からの POST を受信して InfluxDB に書き込み。ingest エンドポイントは Bearer トークンで保護
  - InfluxDB `2.7.12` — StatefulSet + Longhorn 10Gi (volumeClaimTemplates)、org/bucket とも `apple-health`
  - Ingress: `apple-health-ingest.toof.jp` (cloudflare-tunnel)
- **apple-health-mcp namespace**
  - [influxdb-mcp-server](https://github.com/idoru/influxdb-mcp-server) `0.2.0` (InfluxDB v2 API / Flux 対応、Streamable HTTP ネイティブ) を node:24-alpine + npx で起動 (obsidian-msp と同じ方式)
- **mcp-gate**
  - immich パターンを踏襲した OAuth ゲートウェイを追加。公開エンドポイント: `https://apple-health-mcp.toof.jp/mcp`
- ApplicationSet に `apple-health` / `apple-health-mcp` を登録

各 workload に NetworkPolicy を設定 (InfluxDB への接続は ingester Pod と apple-health-mcp の MCP Pod のみ許可)。

## マージ後に必要な作業

**GCP Secret Manager** に以下のシークレットを作成:
- `apple-health-influxdb-password` — InfluxDB admin パスワード
- `apple-health-influxdb-token` — InfluxDB admin トークン (ingester / MCP server で共用)
- `apple-health-ingester-token` — ingest エンドポイントの Bearer トークン

**1Password** に mcp-gate 用エントリを作成 (immich と同様):
- `mcp-gate/apple-health/{authorization-server,jwks-uri,expected-issuer,expected-audience}`

**iOS 側設定** (Health Auto Export):
- URL: `https://apple-health-ingest.toof.jp/api/healthautoexport/v1/influxdb/ingest`
- Export format: JSON、ヘッダ `Authorization: Bearer <apple-health-ingester-token>`

## 補足 (opencode レビューより)

- InfluxDB admin トークンを ingester / MCP の 3 箇所で共用しています。MCP 用に read-only トークンを分離する場合は InfluxDB 起動後に手動でトークンを発行して別シークレット化する必要があるため、初期構築では共用としました
- MCP server は起動時に npx でパッケージを取得します (obsidian-msp と同じトレードオフ)

## Test plan

- [ ] `kubectl apply --dry-run=client` 全マニフェスト通過済み
- [ ] argocd-diff-preview の差分確認
- [ ] マージ後: シークレット作成 → ArgoCD sync → iOS からの ingest 疎通 → MCP エンドポイント疎通

🤖 Generated with [Claude Code](https://claude.com/claude-code)