### PR TITLE
fix(terraform): reopen SSH bootstrap ingress on OCI security list

### DIFF
--- a/terraform/oci.tf
+++ b/terraform/oci.tf
@@ -60,6 +60,20 @@ resource "oci_core_default_security_list" "k8s" {
 
   # SSH is not exposed publicly; access is over Tailscale (same policy as
   # vultr-vps, see vultr.tf).
+  #
+  # TEMPORARY bootstrap exception: neither OCI host runs Tailscale yet, so
+  # the tailscale-only policy from PR #183 locked out all SSH access before
+  # the mesh existed. Keep TCP/22 open until oci-vps has joined the tailnet,
+  # then remove this rule to restore the intended policy.
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
 
   ingress_security_rules {
     protocol = "1"


### PR DESCRIPTION
## 概要

PR #183 のセキュリティ強化でOCIセキュリティリストから公開SSH(TCP/22)が削除されましたが、OCIの2インスタンス（oci-vps / 旧Micro）には**まだTailscaleが導入されていない**ため、SSH経路が完全に失われました（現在両ホストにログイン不能。80/443は無事なのでnemousuリダイレクトは稼働継続中）。

oci-vpsのノード化ブートストラップ（NixOS化の起動確認 → Tailscale導入）にSSHが必須のため、**一時的に**TCP/22のingressを復活させます。

## 撤去条件

oci-vpsがtailnetに参加してTailscale経由のSSHが確認でき次第、このルールを削除するPRを出し、#183の意図（Tailscaleオンリー）に戻します。コード内コメントにも明記済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)