### PR TITLE
feat: add Auth0 client and API for Apple Health MCP connector

### DIFF
--- a/terraform/mcp.tf
+++ b/terraform/mcp.tf
@@ -3,6 +3,9 @@ locals {
   obsidian_mcp_url      = "https://${local.obsidian_mcp_hostname}"
   immich_mcp_hostname   = "immich-mcp.${var.domain}"
   immich_mcp_url        = "https://${local.immich_mcp_hostname}"
+
+  apple_health_mcp_hostname = "apple-health-mcp.${var.domain}"
+  apple_health_mcp_url      = "https://${local.apple_health_mcp_hostname}"
 }
 
 resource "auth0_client" "obsidian_mcp" {
@@ -82,6 +85,46 @@ resource "auth0_resource_server" "immich_mcp" {
 
 resource "auth0_resource_server_scopes" "immich_mcp" {
   resource_server_identifier = auth0_resource_server.immich_mcp.identifier
+  scopes {
+    name        = "mcp:tools"
+    description = "MCP tools access"
+  }
+}
+
+resource "auth0_client" "apple_health_mcp" {
+  name        = "apple-health-mcp"
+  app_type    = "regular_web"
+  description = "Claude remote MCP connector for the Apple Health InfluxDB data."
+
+  callbacks = [
+    "https://claude.ai/api/mcp/auth_callback",
+    "https://claude.com/api/mcp/auth_callback",
+  ]
+
+  allowed_logout_urls = []
+
+  grant_types = [
+    "authorization_code",
+    "refresh_token",
+  ]
+
+  oidc_conformant = true
+}
+
+resource "auth0_client_credentials" "apple_health_mcp" {
+  client_id             = auth0_client.apple_health_mcp.id
+  authentication_method = "client_secret_post"
+}
+
+resource "auth0_resource_server" "apple_health_mcp" {
+  name                 = "apple-health-mcp-api"
+  identifier           = "${local.apple_health_mcp_url}/"
+  signing_alg          = "RS256"
+  allow_offline_access = true
+}
+
+resource "auth0_resource_server_scopes" "apple_health_mcp" {
+  resource_server_identifier = auth0_resource_server.apple_health_mcp.identifier
   scopes {
     name        = "mcp:tools"
     description = "MCP tools access"

--- a/terraform/mcp_outputs.tf
+++ b/terraform/mcp_outputs.tf
@@ -54,3 +54,24 @@ output "immich_mcp_audience" {
   value       = auth0_resource_server.immich_mcp.identifier
   description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
 }
+
+output "auth0_apple_health_mcp_client_id" {
+  value       = auth0_client.apple_health_mcp.client_id
+  description = "OAuth client ID for the Claude Apple Health MCP connector."
+}
+
+output "auth0_apple_health_mcp_client_secret" {
+  value       = auth0_client_credentials.apple_health_mcp.client_secret
+  description = "OAuth client secret for the Claude Apple Health MCP connector."
+  sensitive   = true
+}
+
+output "apple_health_mcp_resource_uri" {
+  value       = local.apple_health_mcp_url
+  description = "Public URL/resource URI for the Apple Health MCP gateway."
+}
+
+output "apple_health_mcp_audience" {
+  value       = auth0_resource_server.apple_health_mcp.identifier
+  description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
+}


### PR DESCRIPTION
## 概要

- apple-health-mcp ゲートウェイを claude.ai のカスタムコネクタとして登録できるよう、Auth0 の Application (`apple-health-mcp`) と Resource Server (`apple-health-mcp-api`, identifier `https://apple-health-mcp.toof.jp/`) を追加
- 既存の immich-mcp / obsidian-mcp と同一パターン
- コネクタ登録に必要な client ID / client secret / audience などの outputs を追加

## マージ後の手順

1. HCP Terraform で apply
2. Auth0 の `apple-health-mcp` Application の Allowed Web Origins に `https://claude.ai` を追加(手動)
3. claude.ai の Settings → Connectors → Add Custom Connector で URL `https://apple-health-mcp.toof.jp/mcp` と `terraform output` の client ID / secret を設定

## テスト

- `terraform fmt -check` 通過
- opencode によるレビュー済み(指摘なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)