### PR TITLE
chore(palworld): scale deployment to 0 replicas

### DIFF
--- a/kubernetes/applications/palworld/palworld.yaml
+++ b/kubernetes/applications/palworld/palworld.yaml
@@ -18,7 +18,7 @@ metadata:
   name: palworld
   namespace: palworld
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## Summary
- Set the palworld Deployment (`kubernetes/applications/palworld/palworld.yaml`) to `replicas: 0` to stop the server.

## Test plan
- [ ] Argo CD syncs and the palworld pod terminates

🤖 Generated with [Claude Code](https://claude.com/claude-code)