### PR TITLE
fix: allow terraform-management role to manage the HCP Terraform OIDC provider

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -50,6 +50,22 @@ data "aws_iam_policy_document" "terraform_management" {
   }
 
   statement {
+    sid = "ManageHCPTerraformOIDCProvider"
+    actions = [
+      "iam:AddClientIDToOpenIDConnectProvider",
+      "iam:CreateOpenIDConnectProvider",
+      "iam:DeleteOpenIDConnectProvider",
+      "iam:GetOpenIDConnectProvider",
+      "iam:ListOpenIDConnectProviderTags",
+      "iam:RemoveClientIDFromOpenIDConnectProvider",
+      "iam:TagOpenIDConnectProvider",
+      "iam:UntagOpenIDConnectProvider",
+      "iam:UpdateOpenIDConnectProviderThumbprint",
+    ]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/app.terraform.io"]
+  }
+
+  statement {
     sid = "ManageTerraformPolicies"
     actions = [
       "iam:CreatePolicy",


### PR DESCRIPTION
## 概要

- #186 の dynamic credentials 移行で `aws_iam_openid_connect_provider` リソースが追加されたが、`terraform-management` ロールの `TerraformManagementPolicy` に `iam:*OpenIDConnectProvider` 系のアクションが付与されておらず、apply が `AccessDenied: iam:CreateOpenIDConnectProvider` で失敗していた
- `ManageHCPTerraformOIDCProvider` statement を追加し、対象を `arn:aws:iam::<account>:oidc-provider/app.terraform.io` のみに限定して OIDC プロバイダの作成・削除・取得・タグ操作・thumbprint 更新を許可

## テスト計画

- [ ] HCP Terraform の speculative plan が成功すること
- [ ] マージ後の apply で `aws_iam_openid_connect_provider.hcp_terraform` と `hcp-terraform-run` ロール、`TFC_*` 変数が作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)