### PR TITLE
Enable tokenless auth for Headlamp via service account

### DIFF
--- a/kubernetes/applications/headlamp.yaml
+++ b/kubernetes/applications/headlamp.yaml
@@ -15,6 +15,8 @@ spec:
       targetRevision: "0.43.0"
       helm:
         valuesObject:
+          config:
+            unsafeUseServiceAccountToken: true
           ingress:
             enabled: true
             ingressClassName: cloudflare-tunnel


### PR DESCRIPTION
## 概要
- Headlamp のトークン入力なしでのログインを有効化 (`config.unsafeUseServiceAccountToken: true`)
- チャート 0.43.0 の `-unsafe-use-service-account-token` フラグにより、全リクエストが Pod の ServiceAccount (チャートデフォルトの ClusterRoleBinding で cluster-admin) として認証される

## セキュリティ境界
このオプションはチャートのドキュメント上「認証プロキシの背後でのみ安全」とされているが、本環境では以下により担保済み:
- 外部アクセスは Cloudflare Tunnel ingress 経由のみで、Cloudflare Access (GitHub SSO) で保護
- NetworkPolicy によりクラスタ内からのアクセスは `cloudflare` namespace のみに制限

## テスト計画
- [ ] ArgoCD sync 後、https://headlamp.toof.jp にアクセスしてトークンプロンプトが出ずにダッシュボードが表示されること
- [ ] Cloudflare Access の認証が引き続き要求されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)