### PR TITLE
Add Dawarich location tracker deployment

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -30,6 +30,8 @@ spec:
             namespace: cdi
           - name: cloudflare-external-secret
             namespace: cloudflare
+          - name: dawarich
+            namespace: dawarich
           - name: dev-vm
             namespace: dev-vm
           - name: external-secrets

--- a/kubernetes/applications/dawarich/dawarich.yaml
+++ b/kubernetes/applications/dawarich/dawarich.yaml
@@ -1,0 +1,190 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dawarich-config
+  namespace: dawarich
+data:
+  RAILS_ENV: production
+  REDIS_URL: redis://redis:6379
+  DATABASE_HOST: postgres
+  DATABASE_PORT: "5432"
+  DATABASE_USERNAME: dawarich
+  DATABASE_NAME: dawarich
+  APPLICATION_HOSTS: dawarich.toof.jp
+  APPLICATION_PROTOCOL: http
+  TIME_ZONE: Asia/Tokyo
+  RAILS_LOG_TO_STDOUT: "true"
+  SELF_HOSTED: "true"
+  STORE_GEODATA: "true"
+  PROMETHEUS_EXPORTER_ENABLED: "false"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dawarich-data
+  namespace: dawarich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dawarich
+  namespace: dawarich
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dawarich
+  template:
+    metadata:
+      labels:
+        app: dawarich
+    spec:
+      containers:
+        - name: app
+          image: freikin/dawarich:1.10.1
+          command:
+            - web-entrypoint.sh
+          args:
+            - bin/rails
+            - server
+            - -p
+            - "3000"
+            - -b
+            - "::"
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: WEB_CONCURRENCY
+              value: "1"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: dawarich-config
+            - secretRef:
+                name: dawarich-secret
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: dawarich-data
+              mountPath: /var/app/public
+              subPath: public
+            - name: dawarich-data
+              mountPath: /var/app/tmp/imports/watched
+              subPath: watched
+            - name: dawarich-data
+              mountPath: /var/app/storage
+              subPath: storage
+        - name: sidekiq
+          image: freikin/dawarich:1.10.1
+          command:
+            - sidekiq-entrypoint.sh
+          args:
+            - sidekiq
+          env:
+            - name: BACKGROUND_PROCESSING_CONCURRENCY
+              value: "3"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: dawarich-config
+            - secretRef:
+                name: dawarich-secret
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - -f
+                - sidekiq
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: dawarich-data
+              mountPath: /var/app/public
+              subPath: public
+            - name: dawarich-data
+              mountPath: /var/app/tmp/imports/watched
+              subPath: watched
+            - name: dawarich-data
+              mountPath: /var/app/storage
+              subPath: storage
+      volumes:
+        - name: dawarich-data
+          persistentVolumeClaim:
+            claimName: dawarich-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dawarich
+  namespace: dawarich
+spec:
+  selector:
+    app: dawarich
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dawarich
+  namespace: dawarich
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: dawarich.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dawarich
+                port:
+                  number: 3000

--- a/kubernetes/applications/dawarich/external-secret.yaml
+++ b/kubernetes/applications/dawarich/external-secret.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-external-secret
+  namespace: dawarich
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: postgres-secret
+    template:
+      type: Opaque
+      data:
+        POSTGRES_USER: dawarich
+        POSTGRES_DB: dawarich
+        POSTGRES_PASSWORD: "{{ .password }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: ClusterGenerator
+          name: password
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dawarich-external-secret
+  namespace: dawarich
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: dawarich-secret
+    template:
+      type: Opaque
+      data:
+        SECRET_KEY_BASE: "{{ .password }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: ClusterGenerator
+          name: password

--- a/kubernetes/applications/dawarich/namespace.yaml
+++ b/kubernetes/applications/dawarich/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dawarich

--- a/kubernetes/applications/dawarich/postgres.yaml
+++ b/kubernetes/applications/dawarich/postgres.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: dawarich
+  labels:
+    app: postgres
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: dawarich
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgis/postgis:17-3.5-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_INITDB_ARGS
+              value: --data-checksums
+          envFrom:
+            - secretRef:
+                name: postgres-secret
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+              subPath: data
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres
+  namespace: dawarich
+spec:
+  podSelector:
+    matchLabels:
+      app: postgres
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: dawarich
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/kubernetes/applications/dawarich/redis.yaml
+++ b/kubernetes/applications/dawarich/redis.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: dawarich
+  labels:
+    app: redis
+spec:
+  clusterIP: None
+  selector:
+    app: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: dawarich
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4-alpine
+          args:
+            - redis-server
+            - --save
+            - "900"
+            - "1"
+            - --save
+            - "300"
+            - "10"
+            - --appendonly
+            - "no"
+          ports:
+            - containerPort: 6379
+              name: redis
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 1Gi
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis
+  namespace: dawarich
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: dawarich
+      ports:
+        - protocol: TCP
+          port: 6379


### PR DESCRIPTION
## 概要

セルフホスト位置情報トラッカー [Dawarich](https://github.com/Freika/dawarich) 1.10.1 をデプロイします。

- **app + sidekiq**: RWO の Longhorn PVC(10Gi)を共有するため同一 Pod 内の 2 コンテナ構成(`strategy: Recreate`)
- **PostgreSQL**: `postgis/postgis:17-3.5-alpine` StatefulSet(Longhorn 10Gi、upstream の docker-compose 同様 `/dev/shm` 1Gi)
- **Redis**: `redis:7.4-alpine` StatefulSet(Longhorn 1Gi、RDB スナップショットのみ)
- **Secret**: DB パスワードと `SECRET_KEY_BASE` は ESO の `password` ClusterGenerator でクラスタ内生成(それぞれ独立した値)。**GCP Secret Manager への手動シークレット登録は不要**
- **NetworkPolicy**: postgres / redis への ingress を dawarich アプリ Pod のみに制限
- **Ingress**: `dawarich.toof.jp`(cloudflare-tunnel)。モバイルアプリ(OwnTracks / Overland 等)が API に直接アクセスするため Zero Trust Access には追加していません(immich と同様)

## テスト

- [x] `kubectl apply --dry-run=client` で全マニフェストの検証済み
- [x] opencode によるレビュー済み(指摘の NetworkPolicy / liveness probe を反映)
- [ ] マージ後、ArgoCD の sync と Pod 起動を確認
- [ ] `dawarich.toof.jp` にアクセスして初期セットアップ(デフォルト認証情報の変更)

🤖 Generated with [Claude Code](https://claude.com/claude-code)