### PR TITLE
Add Beancount MCP server behind mcp-gate

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -24,6 +24,8 @@ spec:
             namespace: bbs
           - name: beancount
             namespace: beancount
+          - name: beancount-mcp
+            namespace: beancount-mcp
           - name: blues
             namespace: blues
           - name: cdi

--- a/kubernetes/applications/beancount-mcp/beancount-mcp.yaml
+++ b/kubernetes/applications/beancount-mcp/beancount-mcp.yaml
@@ -1,0 +1,176 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: beancount-mcp-git-ssh
+  namespace: beancount-mcp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: 1password-sdk
+    kind: ClusterSecretStore
+  target:
+    name: beancount-mcp-git-ssh
+    template:
+      engineVersion: v2
+      data:
+        # 1Password SDK strips the trailing newline; OpenSSH refuses a key
+        # without it ("error in libcrypto"), so re-append via block scalar.
+        id_ed25519: |
+          {{ .id_ed25519 }}
+        known_hosts: |
+          {{ .known_hosts }}
+  data:
+    - secretKey: id_ed25519
+      remoteRef:
+        key: beancount/git-ssh/id_ed25519
+    - secretKey: known_hosts
+      remoteRef:
+        key: beancount/git-ssh/known_hosts
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: beancount-mcp
+  namespace: beancount-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: beancount-mcp
+  template:
+    metadata:
+      labels:
+        app: beancount-mcp
+    spec:
+      securityContext:
+        fsGroup: 65533 # git-sync runs as UID 65533; makes the SSH key group-readable
+      initContainers:
+        - name: git-sync
+          image: registry.k8s.io/git-sync/git-sync:v4.7.1
+          restartPolicy: Always
+          args:
+            - --repo=git@github.com:toof-jp/beancount-ledger.git
+            - --ref=main
+            - --period=60s
+            - --root=/data
+            - --link=current
+            - --ssh-key-file=/etc/git-secret/id_ed25519
+            - --ssh-known-hosts-file=/etc/git-secret/known_hosts
+          startupProbe:
+            exec:
+              command: ["test", "-e", "/data/current"]
+            periodSeconds: 5
+            failureThreshold: 60
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          volumeMounts:
+            - name: repo
+              mountPath: /data
+            - name: git-ssh
+              mountPath: /etc/git-secret
+              readOnly: true
+      containers:
+        - name: beancount-mcp
+          image: ghcr.io/toof-jp/beancount-mcp-server:sha-ec0387a
+          # The image entrypoint speaks stdio; serve Streamable HTTP at /mcp
+          # for mcp-gate instead.
+          command:
+            - python
+            - -c
+            - |
+              from beancount_mcp_server.server import mcp
+              mcp.settings.host = "0.0.0.0"
+              mcp.settings.port = 3000
+              mcp.run(transport="streamable-http")
+          env:
+            - name: BEANCOUNT_FILE
+              value: /data/current/ledger.beancount
+          ports:
+            - name: http
+              containerPort: 3000
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: repo
+              mountPath: /data
+              readOnly: true
+      volumes:
+        - name: repo
+          emptyDir: {}
+        - name: git-ssh
+          secret:
+            secretName: beancount-mcp-git-ssh
+            defaultMode: 0440
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: beancount-mcp
+  namespace: beancount-mcp
+spec:
+  selector:
+    app: beancount-mcp
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: beancount-mcp
+  namespace: beancount-mcp
+spec:
+  podSelector:
+    matchLabels:
+      app: beancount-mcp
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-gate
+          podSelector:
+            matchLabels:
+              app: mcp-gate-beancount
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # git-sync fetches the ledger over SSH
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 22
+        - protocol: TCP
+          port: 443

--- a/kubernetes/applications/beancount-mcp/ghcr-auth.yaml
+++ b/kubernetes/applications/beancount-mcp/ghcr-auth.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: beancount-mcp
+imagePullSecrets:
+  - name: ghcr-auth
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ghcr-auth
+  namespace: beancount-mcp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: ghcr-auth
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "ghcr.io": {
+                "username": "toof-jp",
+                "password": "{{ .pat }}",
+                "email": "unused@example.com",
+                "auth": "{{ printf "%s:%s" "toof-jp" .pat | b64enc }}"
+              }
+            }
+          }
+  data:
+    - secretKey: pat
+      remoteRef:
+        key: ghcr-pat

--- a/kubernetes/applications/beancount-mcp/namespace.yaml
+++ b/kubernetes/applications/beancount-mcp/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: beancount-mcp

--- a/kubernetes/applications/mcp-gate/README.md
+++ b/kubernetes/applications/mcp-gate/README.md
@@ -90,3 +90,34 @@ In the `immich-mcp` Auth0 Application, add `https://claude.ai` to Allowed Web Or
 3. Advanced settings -> OAuth Client ID: `terraform output -raw auth0_immich_mcp_client_id`
 4. Advanced settings -> OAuth Client Secret: `terraform output -raw auth0_immich_mcp_client_secret`
 5. Add, sign in on the Auth0 screen, and finish the connector setup.
+
+## Beancount MCP Gateway
+
+`beancount.yaml` exposes the Beancount MCP endpoint at:
+
+```text
+https://beancount-mcp.toof.jp/mcp
+```
+
+The upstream is [toof-jp/beancount-mcp-server](https://github.com/toof-jp/beancount-mcp-server) running in the `beancount-mcp` namespace (`kubernetes/applications/beancount-mcp/`), serving Streamable HTTP at `/mcp` on port 3000. The ledger is git-synced from `toof-jp/beancount-ledger` (same SSH key as the fava app) and mounted read-only, so the server's write tools (`add_transaction`, `append_entry`) fail by design; the connector is effectively read-only.
+
+### Secret Values
+
+Populate the `mcp-gate/beancount/*` 1Password items from Terraform outputs:
+
+- `mcp-gate/beancount/authorization-server`: `terraform output -raw auth0_obsidian_mcp_issuer`
+- `mcp-gate/beancount/jwks-uri`: `terraform output -raw auth0_obsidian_mcp_jwks_uri`
+- `mcp-gate/beancount/expected-issuer`: `terraform output -raw auth0_obsidian_mcp_issuer`
+- `mcp-gate/beancount/expected-audience`: `terraform output -raw beancount_mcp_audience`
+
+### Auth0 Manual Settings
+
+In the `beancount-mcp` Auth0 Application, add `https://claude.ai` to Allowed Web Origins. The tenant-wide Resource Parameter Compatibility Profile is already enabled.
+
+### Claude Connector
+
+1. Settings -> Connectors -> Add Custom Connector
+2. Remote MCP server URL: `https://beancount-mcp.toof.jp/mcp`
+3. Advanced settings -> OAuth Client ID: `terraform output -raw auth0_beancount_mcp_client_id`
+4. Advanced settings -> OAuth Client Secret: `terraform output -raw auth0_beancount_mcp_client_secret`
+5. Add, sign in on the Auth0 screen, and finish the connector setup.

--- a/kubernetes/applications/mcp-gate/beancount.yaml
+++ b/kubernetes/applications/mcp-gate/beancount.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mcp-gate-beancount
+  namespace: mcp-gate
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: 1password-sdk
+    kind: ClusterSecretStore
+  target:
+    name: mcp-gate-beancount-secret
+  data:
+    - secretKey: AUTHORIZATION_SERVER
+      remoteRef:
+        key: mcp-gate/beancount/authorization-server
+    - secretKey: JWKS_URI
+      remoteRef:
+        key: mcp-gate/beancount/jwks-uri
+    - secretKey: EXPECTED_ISSUER
+      remoteRef:
+        key: mcp-gate/beancount/expected-issuer
+    - secretKey: EXPECTED_AUDIENCE
+      remoteRef:
+        key: mcp-gate/beancount/expected-audience
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-gate-beancount-config
+  namespace: mcp-gate
+data:
+  LISTEN_ADDR: 0.0.0.0:8080
+  RESOURCE_URI: https://beancount-mcp.toof.jp/
+  UPSTREAM_URL: http://beancount-mcp.beancount-mcp.svc.cluster.local:3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-gate-beancount
+  namespace: mcp-gate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-gate-beancount
+  template:
+    metadata:
+      labels:
+        app: mcp-gate-beancount
+    spec:
+      containers:
+        - name: mcp-gate
+          image: cpremus/mcp-gate:0.16.28
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: mcp-gate-beancount-config
+            - secretRef:
+                name: mcp-gate-beancount-secret
+          readinessProbe:
+            httpGet:
+              path: /.well-known/oauth-protected-resource
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /.well-known/oauth-protected-resource
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-gate-beancount
+  namespace: mcp-gate
+spec:
+  selector:
+    app: mcp-gate-beancount
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-gate-beancount
+  namespace: mcp-gate
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: beancount-mcp.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-gate-beancount
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-gate-beancount
+  namespace: mcp-gate
+spec:
+  podSelector:
+    matchLabels:
+      app: mcp-gate-beancount
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: beancount-mcp
+          podSelector:
+            matchLabels:
+              app: beancount-mcp
+      ports:
+        - protocol: TCP
+          port: 3000
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/terraform/mcp.tf
+++ b/terraform/mcp.tf
@@ -6,6 +6,9 @@ locals {
 
   apple_health_mcp_hostname = "apple-health-mcp.${var.domain}"
   apple_health_mcp_url      = "https://${local.apple_health_mcp_hostname}"
+
+  beancount_mcp_hostname = "beancount-mcp.${var.domain}"
+  beancount_mcp_url      = "https://${local.beancount_mcp_hostname}"
 }
 
 resource "auth0_client" "obsidian_mcp" {
@@ -125,6 +128,46 @@ resource "auth0_resource_server" "apple_health_mcp" {
 
 resource "auth0_resource_server_scopes" "apple_health_mcp" {
   resource_server_identifier = auth0_resource_server.apple_health_mcp.identifier
+  scopes {
+    name        = "mcp:tools"
+    description = "MCP tools access"
+  }
+}
+
+resource "auth0_client" "beancount_mcp" {
+  name        = "beancount-mcp"
+  app_type    = "regular_web"
+  description = "Claude remote MCP connector for the Beancount ledger."
+
+  callbacks = [
+    "https://claude.ai/api/mcp/auth_callback",
+    "https://claude.com/api/mcp/auth_callback",
+  ]
+
+  allowed_logout_urls = []
+
+  grant_types = [
+    "authorization_code",
+    "refresh_token",
+  ]
+
+  oidc_conformant = true
+}
+
+resource "auth0_client_credentials" "beancount_mcp" {
+  client_id             = auth0_client.beancount_mcp.id
+  authentication_method = "client_secret_post"
+}
+
+resource "auth0_resource_server" "beancount_mcp" {
+  name                 = "beancount-mcp-api"
+  identifier           = "${local.beancount_mcp_url}/"
+  signing_alg          = "RS256"
+  allow_offline_access = true
+}
+
+resource "auth0_resource_server_scopes" "beancount_mcp" {
+  resource_server_identifier = auth0_resource_server.beancount_mcp.identifier
   scopes {
     name        = "mcp:tools"
     description = "MCP tools access"

--- a/terraform/mcp_outputs.tf
+++ b/terraform/mcp_outputs.tf
@@ -75,3 +75,24 @@ output "apple_health_mcp_audience" {
   value       = auth0_resource_server.apple_health_mcp.identifier
   description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
 }
+
+output "auth0_beancount_mcp_client_id" {
+  value       = auth0_client.beancount_mcp.client_id
+  description = "OAuth client ID for the Claude Beancount MCP connector."
+}
+
+output "auth0_beancount_mcp_client_secret" {
+  value       = auth0_client_credentials.beancount_mcp.client_secret
+  description = "OAuth client secret for the Claude Beancount MCP connector."
+  sensitive   = true
+}
+
+output "beancount_mcp_resource_uri" {
+  value       = local.beancount_mcp_url
+  description = "Public URL/resource URI for the Beancount MCP gateway."
+}
+
+output "beancount_mcp_audience" {
+  value       = auth0_resource_server.beancount_mcp.identifier
+  description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
+}


### PR DESCRIPTION
## Summary
- New `beancount-mcp` app: runs [toof-jp/beancount-mcp-server](https://github.com/toof-jp/beancount-mcp-server) (`sha-ec0387a`), git-syncs the ledger from `beancount-ledger` (same SSH key items as the fava app) and serves Streamable HTTP at `/mcp` on port 3000. The stdio entrypoint is overridden inline to run FastMCP's streamable-http transport, mirroring the obsidian-msp mcp-proxy approach.
- New `mcp-gate/beancount.yaml` gateway at `https://beancount-mcp.toof.jp/mcp` (apple-health pattern: ConfigMap, ExternalSecret `mcp-gate/beancount/*`, Ingress via cloudflare-tunnel, NetworkPolicy).
- Terraform: `beancount-mcp` Auth0 client + resource server + outputs (immich pattern).
- The ledger volume is mounted read-only, so the server's write tools fail by design — the connector is effectively read-only.

## Post-merge manual steps
- [ ] `terraform output` the new values and create the `mcp-gate/beancount/*` 1Password items (see mcp-gate README)
- [ ] Add `https://claude.ai` to Allowed Web Origins in the `beancount-mcp` Auth0 Application
- [ ] Add the Claude custom connector with the new client ID/secret

## Test plan
- [x] `terraform fmt -check -recursive`
- [x] `prettier --check "**/*.yaml"`
- [ ] kubeconform CI green
- [ ] Argo CD syncs `beancount-mcp` and pod becomes Ready
- [ ] `https://beancount-mcp.toof.jp/mcp` completes the OAuth handshake from Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)