### PR TITLE
Add dawarich-mcp server and gateway

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -34,6 +34,8 @@ spec:
             namespace: cloudflare
           - name: dawarich
             namespace: dawarich
+          - name: dawarich-mcp
+            namespace: dawarich-mcp
           - name: dev-vm
             namespace: dev-vm
           - name: external-secrets

--- a/kubernetes/applications/dawarich-mcp/dawarich-mcp.yaml
+++ b/kubernetes/applications/dawarich-mcp/dawarich-mcp.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dawarich-mcp
+  namespace: dawarich-mcp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: dawarich-mcp-secret
+  data:
+    - secretKey: DAWARICH_API_KEY
+      remoteRef:
+        key: dawarich-mcp-api-key
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dawarich-mcp-config
+  namespace: dawarich-mcp
+data:
+  DAWARICH_BASE_URL: http://dawarich.dawarich.svc.cluster.local:3000
+  MCP_PORT: "3000"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dawarich-mcp
+  namespace: dawarich-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dawarich-mcp
+  template:
+    metadata:
+      labels:
+        app: dawarich-mcp
+    spec:
+      containers:
+        - name: dawarich-mcp
+          image: ghcr.io/toof-jp/dawarich-mcp-server:latest
+          ports:
+            - name: http
+              containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: dawarich-mcp-config
+            - secretRef:
+                name: dawarich-mcp-secret
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dawarich-mcp
+  namespace: dawarich-mcp
+spec:
+  selector:
+    app: dawarich-mcp
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dawarich-mcp
+  namespace: dawarich-mcp
+spec:
+  podSelector:
+    matchLabels:
+      app: dawarich-mcp
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-gate
+          podSelector:
+            matchLabels:
+              app: mcp-gate-dawarich
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: dawarich
+          podSelector:
+            matchLabels:
+              app: dawarich
+      ports:
+        - protocol: TCP
+          port: 3000
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/kubernetes/applications/dawarich-mcp/ghcr-auth.yaml
+++ b/kubernetes/applications/dawarich-mcp/ghcr-auth.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: dawarich-mcp
+imagePullSecrets:
+  - name: ghcr-auth
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ghcr-auth
+  namespace: dawarich-mcp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: ghcr-auth
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "ghcr.io": {
+                "username": "toof-jp",
+                "password": "{{ .pat }}",
+                "email": "unused@example.com",
+                "auth": "{{ printf "%s:%s" "toof-jp" .pat | b64enc }}"
+              }
+            }
+          }
+  data:
+    - secretKey: pat
+      remoteRef:
+        key: ghcr-pat

--- a/kubernetes/applications/dawarich-mcp/namespace.yaml
+++ b/kubernetes/applications/dawarich-mcp/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dawarich-mcp

--- a/kubernetes/applications/mcp-gate/README.md
+++ b/kubernetes/applications/mcp-gate/README.md
@@ -121,3 +121,36 @@ In the `beancount-mcp` Auth0 Application, add `https://claude.ai` to Allowed Web
 3. Advanced settings -> OAuth Client ID: `terraform output -raw auth0_beancount_mcp_client_id`
 4. Advanced settings -> OAuth Client Secret: `terraform output -raw auth0_beancount_mcp_client_secret`
 5. Add, sign in on the Auth0 screen, and finish the connector setup.
+
+## Dawarich MCP Gateway
+
+`dawarich.yaml` exposes the Dawarich MCP endpoint at:
+
+```text
+https://dawarich-mcp.toof.jp/mcp
+```
+
+The upstream is [toof-jp/dawarich-mcp-server](https://github.com/toof-jp/dawarich-mcp-server) running in the `dawarich-mcp` namespace (`kubernetes/applications/dawarich-mcp/`), serving Streamable HTTP at `/mcp` on port 3000. It exposes read-only tools over the Dawarich API of the in-cluster Dawarich instance (`dawarich` namespace).
+
+### Secret Values
+
+Populate the `mcp-gate/dawarich/*` 1Password items from Terraform outputs:
+
+- `mcp-gate/dawarich/authorization-server`: `terraform output -raw auth0_obsidian_mcp_issuer`
+- `mcp-gate/dawarich/jwks-uri`: `terraform output -raw auth0_obsidian_mcp_jwks_uri`
+- `mcp-gate/dawarich/expected-issuer`: `terraform output -raw auth0_obsidian_mcp_issuer`
+- `mcp-gate/dawarich/expected-audience`: `terraform output -raw dawarich_mcp_audience`
+
+The Dawarich API key comes from GCP Secret Manager (`dawarich-mcp-api-key`). Copy it from the Dawarich UI (Account Settings) after creating the user; the MCP server only performs GET requests.
+
+### Auth0 Manual Settings
+
+In the `dawarich-mcp` Auth0 Application, add `https://claude.ai` to Allowed Web Origins. The tenant-wide Resource Parameter Compatibility Profile is already enabled.
+
+### Claude Connector
+
+1. Settings -> Connectors -> Add Custom Connector
+2. Remote MCP server URL: `https://dawarich-mcp.toof.jp/mcp`
+3. Advanced settings -> OAuth Client ID: `terraform output -raw auth0_dawarich_mcp_client_id`
+4. Advanced settings -> OAuth Client Secret: `terraform output -raw auth0_dawarich_mcp_client_secret`
+5. Add, sign in on the Auth0 screen, and finish the connector setup.

--- a/kubernetes/applications/mcp-gate/dawarich.yaml
+++ b/kubernetes/applications/mcp-gate/dawarich.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mcp-gate-dawarich
+  namespace: mcp-gate
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: 1password-sdk
+    kind: ClusterSecretStore
+  target:
+    name: mcp-gate-dawarich-secret
+  data:
+    - secretKey: AUTHORIZATION_SERVER
+      remoteRef:
+        key: mcp-gate/dawarich/authorization-server
+    - secretKey: JWKS_URI
+      remoteRef:
+        key: mcp-gate/dawarich/jwks-uri
+    - secretKey: EXPECTED_ISSUER
+      remoteRef:
+        key: mcp-gate/dawarich/expected-issuer
+    - secretKey: EXPECTED_AUDIENCE
+      remoteRef:
+        key: mcp-gate/dawarich/expected-audience
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-gate-dawarich-config
+  namespace: mcp-gate
+data:
+  LISTEN_ADDR: 0.0.0.0:8080
+  RESOURCE_URI: https://dawarich-mcp.toof.jp/
+  UPSTREAM_URL: http://dawarich-mcp.dawarich-mcp.svc.cluster.local:3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-gate-dawarich
+  namespace: mcp-gate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-gate-dawarich
+  template:
+    metadata:
+      labels:
+        app: mcp-gate-dawarich
+    spec:
+      containers:
+        - name: mcp-gate
+          image: cpremus/mcp-gate:0.16.28
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: mcp-gate-dawarich-config
+            - secretRef:
+                name: mcp-gate-dawarich-secret
+          readinessProbe:
+            httpGet:
+              path: /.well-known/oauth-protected-resource
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /.well-known/oauth-protected-resource
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-gate-dawarich
+  namespace: mcp-gate
+spec:
+  selector:
+    app: mcp-gate-dawarich
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-gate-dawarich
+  namespace: mcp-gate
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: dawarich-mcp.toof.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-gate-dawarich
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-gate-dawarich
+  namespace: mcp-gate
+spec:
+  podSelector:
+    matchLabels:
+      app: mcp-gate-dawarich
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: dawarich-mcp
+          podSelector:
+            matchLabels:
+              app: dawarich-mcp
+      ports:
+        - protocol: TCP
+          port: 3000
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/terraform/mcp.tf
+++ b/terraform/mcp.tf
@@ -9,6 +9,9 @@ locals {
 
   beancount_mcp_hostname = "beancount-mcp.${var.domain}"
   beancount_mcp_url      = "https://${local.beancount_mcp_hostname}"
+
+  dawarich_mcp_hostname = "dawarich-mcp.${var.domain}"
+  dawarich_mcp_url      = "https://${local.dawarich_mcp_hostname}"
 }
 
 resource "auth0_client" "obsidian_mcp" {
@@ -168,6 +171,46 @@ resource "auth0_resource_server" "beancount_mcp" {
 
 resource "auth0_resource_server_scopes" "beancount_mcp" {
   resource_server_identifier = auth0_resource_server.beancount_mcp.identifier
+  scopes {
+    name        = "mcp:tools"
+    description = "MCP tools access"
+  }
+}
+
+resource "auth0_client" "dawarich_mcp" {
+  name        = "dawarich-mcp"
+  app_type    = "regular_web"
+  description = "Claude remote MCP connector for the Dawarich location history."
+
+  callbacks = [
+    "https://claude.ai/api/mcp/auth_callback",
+    "https://claude.com/api/mcp/auth_callback",
+  ]
+
+  allowed_logout_urls = []
+
+  grant_types = [
+    "authorization_code",
+    "refresh_token",
+  ]
+
+  oidc_conformant = true
+}
+
+resource "auth0_client_credentials" "dawarich_mcp" {
+  client_id             = auth0_client.dawarich_mcp.id
+  authentication_method = "client_secret_post"
+}
+
+resource "auth0_resource_server" "dawarich_mcp" {
+  name                 = "dawarich-mcp-api"
+  identifier           = "${local.dawarich_mcp_url}/"
+  signing_alg          = "RS256"
+  allow_offline_access = true
+}
+
+resource "auth0_resource_server_scopes" "dawarich_mcp" {
+  resource_server_identifier = auth0_resource_server.dawarich_mcp.identifier
   scopes {
     name        = "mcp:tools"
     description = "MCP tools access"

--- a/terraform/mcp_outputs.tf
+++ b/terraform/mcp_outputs.tf
@@ -96,3 +96,24 @@ output "beancount_mcp_audience" {
   value       = auth0_resource_server.beancount_mcp.identifier
   description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
 }
+
+output "auth0_dawarich_mcp_client_id" {
+  value       = auth0_client.dawarich_mcp.client_id
+  description = "OAuth client ID for the Claude Dawarich MCP connector."
+}
+
+output "auth0_dawarich_mcp_client_secret" {
+  value       = auth0_client_credentials.dawarich_mcp.client_secret
+  description = "OAuth client secret for the Claude Dawarich MCP connector."
+  sensitive   = true
+}
+
+output "dawarich_mcp_resource_uri" {
+  value       = local.dawarich_mcp_url
+  description = "Public URL/resource URI for the Dawarich MCP gateway."
+}
+
+output "dawarich_mcp_audience" {
+  value       = auth0_resource_server.dawarich_mcp.identifier
+  description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
+}


### PR DESCRIPTION
## Summary
- New `dawarich-mcp` namespace running [toof-jp/dawarich-mcp-server](https://github.com/toof-jp/dawarich-mcp-server) that proxies the in-cluster Dawarich API (`dawarich` namespace), with `ghcr-auth` and a locked-down NetworkPolicy
- New `mcp-gate/dawarich` gateway exposing it at `https://dawarich-mcp.toof.jp/mcp`, cloudflare-tunnel Ingress and Auth0 JWT validation via 1Password-backed ExternalSecret
- Auth0 client / resource server / outputs in Terraform following the existing beancount-mcp pattern; README section added under `mcp-gate/`

## Manual follow-up (in order)
1. Merge toof-jp/dawarich-mcp-server#1 so `ghcr.io/toof-jp/dawarich-mcp-server:latest` gets published (otherwise the Pod will ImagePullBackOff on first sync)
2. After HCP Terraform applies, populate the `mcp-gate/dawarich/*` 1Password items from the new `terraform output` values
3. In the Dawarich UI (`https://dawarich.toof.jp`), create an API key and store it in GCP Secret Manager as `dawarich-mcp-api-key`
4. In the Auth0 `dawarich-mcp` Application, add `https://claude.ai` to Allowed Web Origins

## Test plan
- [ ] Argo CD syncs `dawarich-mcp` and `mcp-gate/dawarich` cleanly
- [ ] `curl https://dawarich-mcp.toof.jp/.well-known/oauth-protected-resource` returns the expected metadata
- [ ] Claude custom connector completes the OAuth flow and lists tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)