### PR TITLE
Fix beancount-mcp 421 by disabling DNS rebinding protection

### DIFF
--- a/kubernetes/applications/beancount-mcp/beancount-mcp.yaml
+++ b/kubernetes/applications/beancount-mcp/beancount-mcp.yaml
@@ -86,6 +86,10 @@ spec:
               from beancount_mcp_server.server import mcp
               mcp.settings.host = "0.0.0.0"
               mcp.settings.port = 3000
+              # FastMCP auto-enables DNS rebinding protection because it is
+              # constructed with the default host=127.0.0.1; drop it so
+              # mcp-gate can proxy requests using the in-cluster hostname.
+              mcp.settings.transport_security = None
               mcp.run(transport="streamable-http")
           env:
             - name: BEANCOUNT_FILE


### PR DESCRIPTION
## Summary
- mcp-gate proxies requests to `beancount-mcp` forwarding the in-cluster Host header (`beancount-mcp.beancount-mcp.svc.cluster.local:3000`).
- FastMCP's `TransportSecurityMiddleware` was set up at module-import time with the default `host=127.0.0.1`, so `allowed_hosts` was locked to `127.0.0.1:*`/`localhost:*`/`[::1]:*` and every proxied request got a **421 Misdirected Request** ([logs](./.)).
- Setting `mcp.settings.host = "0.0.0.0"` after the fact doesn't undo the auto-enabled protection. Explicitly clear `transport_security` before `mcp.run()`.

Safe because auth is enforced upstream by mcp-gate JWT validation and ingress to port 3000 is limited to the mcp-gate pods by NetworkPolicy.

## Test plan
- [x] `prettier --check "**/*.yaml"`
- [ ] After merge: `POST /mcp` from mcp-gate returns 200 instead of 421
- [ ] Claude connector completes handshake against `https://beancount-mcp.toof.jp/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)