### PR TITLE
Allow in-cluster Host header for Dawarich

### DIFF
--- a/kubernetes/applications/dawarich/dawarich.yaml
+++ b/kubernetes/applications/dawarich/dawarich.yaml
@@ -11,7 +11,9 @@ data:
   DATABASE_PORT: "5432"
   DATABASE_USERNAME: dawarich
   DATABASE_NAME: dawarich
-  APPLICATION_HOSTS: dawarich.toof.jp
+  # Include the in-cluster DNS name so dawarich-mcp (and any other in-cluster
+  # client) is not blocked by Rails' HostAuthorization middleware.
+  APPLICATION_HOSTS: dawarich.toof.jp,dawarich.dawarich.svc.cluster.local
   APPLICATION_PROTOCOL: http
   TIME_ZONE: Asia/Tokyo
   RAILS_LOG_TO_STDOUT: "true"


### PR DESCRIPTION
## Summary
- Adds `dawarich.dawarich.svc.cluster.local` to `APPLICATION_HOSTS` on the Dawarich ConfigMap
- Rails' HostAuthorization middleware was returning empty 403s for every dawarich-mcp -> Dawarich request because only `dawarich.toof.jp` was allowed; the health endpoint is excluded from host auth so it looked green

## Test plan
- [ ] After Argo CD sync and Dawarich pod restart, `curl` from a `dawarich-mcp` pod against `http://dawarich.dawarich.svc.cluster.local:3000/api/v1/user?api_key=...` returns 200 JSON
- [ ] Claude MCP calls succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)