### PR TITLE
feat(bbs): deploy nemousu.live-on.net redirector on sakura-vps

### DIFF
--- a/kubernetes/applications/bbs/nemousu-redirector.yaml
+++ b/kubernetes/applications/bbs/nemousu-redirector.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nemousu-redirector
+  namespace: bbs
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: nemousu-redirector
+  template:
+    metadata:
+      labels:
+        app: nemousu-redirector
+    spec:
+      # Pinned to sakura-vps because the public DNS A record for
+      # nemousu.live-on.net points at this node's fixed IP
+      # (153.126.161.157) and traffic is served via NodePort on that node.
+      nodeSelector:
+        kubernetes.io/hostname: sakura-vps
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: caddy
+          image: ghcr.io/toof-jp/nemousu-live-on-net-redirector:latest
+          ports:
+            - name: http
+              containerPort: 80
+            - name: https
+              containerPort: 443
+          volumeMounts:
+            - name: caddy-data
+              mountPath: /data
+            - name: caddy-config
+              mountPath: /config
+      volumes:
+        - name: caddy-data
+          emptyDir: {}
+        - name: caddy-config
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nemousu-redirector
+  namespace: bbs
+spec:
+  type: NodePort
+  selector:
+    app: nemousu-redirector
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      nodePort: 30080
+    - name: https
+      port: 443
+      targetPort: https
+      nodePort: 30443


### PR DESCRIPTION
## Summary
- Adds `kubernetes/applications/bbs/nemousu-redirector.yaml`: Deployment + NodePort Service running `ghcr.io/toof-jp/nemousu-live-on-net-redirector` on `sakura-vps` (control-plane toleration + `nodeSelector`).
- Service exposes `NodePort` 30080 (HTTP) and 30443 (HTTPS); Caddy handles auto-HTTPS once port 80 is reachable end-to-end.
- Deployed into the existing `bbs` namespace (no new ApplicationSet entry needed).

## Prereqs (out-of-band; not in this PR)
1. Companion PR against `toof-jp/nemousu.live-on.net-redirector-image` merged and the GHCR image published.
2. sakura-vps NixOS: `networking.firewall.allowedTCPPorts` gains `80` and `443`; nftables NAT `:80 → :30080`, `:443 → :30443` on `ens3`.
3. Sakura control-panel packet filter: allow TCP 80/443 to `153.126.161.157`.
4. `nemousu.live-on.net` A record → `153.126.161.157` (1Password `mydns.jp/IPV4ADDR` already updated; existing `bbs/mydns-jp-updater` CronJob will push it on its next run).

## Test plan
- [ ] After Argo CD sync, `kubectl -n bbs get pods -l app=nemousu-redirector` shows Running on `sakura-vps`.
- [ ] From the tailnet or the node itself: `curl -I http://100.117.158.100:30080/bbs/search?identifier=abc` returns `301` to `https://nemousu.pages.dev/?id=abc`.
- [ ] Once host-side ports are open: `curl -I "http://nemousu.live-on.net/bbs/search?identifier=abc"` returns the same 301 externally.
- [ ] `curl -I "https://nemousu.live-on.net/oekaki?identifier=xyz"` succeeds after Let's Encrypt issues the cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)