### PR TITLE
fix(bbs): pin nemousu-redirector image to sha- tag

### DIFF
--- a/kubernetes/applications/bbs/nemousu-redirector.yaml
+++ b/kubernetes/applications/bbs/nemousu-redirector.yaml
@@ -27,7 +27,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: caddy
-          image: ghcr.io/toof-jp/nemousu-live-on-net-redirector:latest
+          image: ghcr.io/toof-jp/nemousu-live-on-net-redirector:sha-b495370
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
## Summary
- Replaces `:latest` with `:sha-b495370` for `ghcr.io/toof-jp/nemousu-live-on-net-redirector`, matching the pinning convention used by `mydns-jp-updater`, `shisha-log-backend`, etc.
- Renovate's `argocd` manager will bump the `sha-<hash>` reference automatically as new images are pushed from `toof-jp/nemousu.live-on.net-redirector-image`.

## Test plan
- [ ] Argo CD reports sync succeeded for the `bbs` app after merge.
- [ ] `kubectl -n bbs get deploy nemousu-redirector -o jsonpath='{.spec.template.spec.containers[0].image}'` shows the sha- tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)