### PR TITLE
chore(deps): update ghcr.io/toof-jp/dawarich-mcp-server:latest docker digest to 38c6dba

### DIFF
--- a/kubernetes/applications/dawarich-mcp/dawarich-mcp.yaml
+++ b/kubernetes/applications/dawarich-mcp/dawarich-mcp.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
         - name: dawarich-mcp
-          image: ghcr.io/toof-jp/dawarich-mcp-server:latest@sha256:285b6f4db79ae1df81c9fc492e8a3f63b671286ec43d032b6a4dee5d81339937
+          image: ghcr.io/toof-jp/dawarich-mcp-server:latest@sha256:38c6dbaeaf70208ba43c672ec9406308ec08368447b8b39f607216f8c80550e1
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
Renovate has this update queued but not yet opened. Publishing it manually so the Pod picks up the sha-ca53c9c build (PR toof-jp/dawarich-mcp-server#3), which aligns the tool endpoints with Dawarich's actual /api/v1 routes.

## Effect on tools
- Fixes: `get_user`, `get_statistics`, `get_visits` (currently 404/500)
- Removes obsolete: `get_monthly_statistics`, `get_trips`, `get_visited_cities`
- Adds: `get_timeline`, `get_flights`, `get_insights_details`, `get_tracked_months`

## Test plan
- [ ] After sync, `mcp__.../get_user` returns 200 body
- [ ] `mcp__.../get_visits` requires `start_at`/`end_at` and returns visits

🤖 Generated with [Claude Code](https://claude.com/claude-code)