### PR TITLE
Add CloudNativePG operator

### DIFF
--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -32,6 +32,8 @@ spec:
             namespace: cdi
           - name: cloudflare-external-secret
             namespace: cloudflare
+          - name: cloudnative-pg
+            namespace: cnpg-system
           - name: dawarich
             namespace: dawarich
           - name: dawarich-mcp

--- a/kubernetes/applications/cloudnative-pg/crd-ssa-patch.yaml
+++ b/kubernetes/applications/cloudnative-pg/crd-ssa-patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: placeholder
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true

--- a/kubernetes/applications/cloudnative-pg/kustomization.yaml
+++ b/kubernetes/applications/cloudnative-pg/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cnpg-system
+resources:
+  - namespace.yaml
+helmCharts:
+  - name: cloudnative-pg
+    repo: https://cloudnative-pg.github.io/charts
+    version: 0.29.0
+    releaseName: cloudnative-pg
+    namespace: cnpg-system
+    includeCRDs: true
+patches:
+  - target:
+      kind: CustomResourceDefinition
+      name: ".*\\.cnpg\\.io"
+    path: crd-ssa-patch.yaml

--- a/kubernetes/applications/cloudnative-pg/namespace.yaml
+++ b/kubernetes/applications/cloudnative-pg/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnpg-system


### PR DESCRIPTION
## 概要

- 既存の Postgres StatefulSet(Immich / Dawarich / BBS / shisha-log)を CloudNativePG(CNPG)Cluster CR に順次置き換えるための下地として、まず operator だけを導入する。
- Helm チャート `cloudnative-pg` v0.29.0(operator 1.30.0)を external-secrets と同じ Kustomize + helmCharts パターンでインストール。
- CNPG の CRD は annotation サイズ制限に引っかかるため、external-secrets と同様に `ServerSideApply=true` パッチを全 CRD(`*.cnpg.io`)に適用。
- ApplicationSet に `cloudnative-pg` エントリを追加し、ArgoCD が自動同期する。

## この PR のスコープ外(後続 PR)

- 各 DB の Cluster CR 作成と `initdb.import` による論理移行(shisha-log → dawarich → immich → bbs の順で 1 DB ずつ)。
- bbs 用 `postgres-bigm-docker` を CNPG ベースイメージへ作り直し。
- ExternalSecret を basic-auth 形式へ調整、immich/bbs の generator を `refreshPolicy: CreatedOnce` 化。
- オブジェクトストレージバックアップは当面設定しない(必要になったら別途)。

## Test plan

- [ ] `kustomize build --enable-helm kubernetes/applications/cloudnative-pg` が成功する(ローカル確認済み: 23 resources, operator image `ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0`, 全 11 CRD に SSA アノテーション)
- [ ] マージ後 ArgoCD で `cloudnative-pg` Application が Synced/Healthy
- [ ] `kubectl -n cnpg-system get deploy,pods` で operator が Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)