### PR TITLE
Add Longhorn backup to Cloudflare R2

### DIFF
--- a/kubernetes/applications/apple-health/influxdb.yaml
+++ b/kubernetes/applications/apple-health/influxdb.yaml
@@ -82,6 +82,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: influxdb-data
+        labels:
+          recurring-job-group.longhorn.io/db-6h: enabled
+          recurring-job-group.longhorn.io/daily: enabled
       spec:
         accessModes:
           - ReadWriteOnce

--- a/kubernetes/applications/applicationset.yaml
+++ b/kubernetes/applications/applicationset.yaml
@@ -46,6 +46,8 @@ spec:
             namespace: immich-mcp
           - name: kubevirt
             namespace: kubevirt
+          - name: longhorn-config
+            namespace: longhorn-system
           - name: mcp-gate
             namespace: mcp-gate
           - name: monitoring

--- a/kubernetes/applications/bbs/db.yaml
+++ b/kubernetes/applications/bbs/db.yaml
@@ -53,6 +53,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: postgres-pvc
   namespace: bbs
+  labels:
+    recurring-job-group.longhorn.io/db-6h: enabled
+    recurring-job-group.longhorn.io/daily: enabled
 spec:
   accessModes:
     - ReadWriteOnce

--- a/kubernetes/applications/dawarich/dawarich.yaml
+++ b/kubernetes/applications/dawarich/dawarich.yaml
@@ -26,6 +26,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: dawarich-data
   namespace: dawarich
+  labels:
+    recurring-job-group.longhorn.io/daily: enabled
 spec:
   accessModes:
     - ReadWriteOnce

--- a/kubernetes/applications/dawarich/postgres.yaml
+++ b/kubernetes/applications/dawarich/postgres.yaml
@@ -79,6 +79,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: postgres-data
+        labels:
+          recurring-job-group.longhorn.io/db-6h: enabled
+          recurring-job-group.longhorn.io/daily: enabled
       spec:
         accessModes:
           - ReadWriteOnce

--- a/kubernetes/applications/dev-vm/vm.yaml
+++ b/kubernetes/applications/dev-vm/vm.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: dev-home
   namespace: dev-vm
+  labels:
+    recurring-job-group.longhorn.io/daily: enabled
 spec:
   accessModes:
     - ReadWriteOnce

--- a/kubernetes/applications/immich/postgres.yaml
+++ b/kubernetes/applications/immich/postgres.yaml
@@ -59,6 +59,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: postgres-data
+        labels:
+          recurring-job-group.longhorn.io/db-6h: enabled
+          recurring-job-group.longhorn.io/daily: enabled
       spec:
         accessModes:
           - ReadWriteOnce

--- a/kubernetes/applications/immich/pvc.yaml
+++ b/kubernetes/applications/immich/pvc.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: immich-library
   namespace: immich
+  labels:
+    recurring-job-group.longhorn.io/daily: enabled
 spec:
   accessModes:
     - ReadWriteOnce

--- a/kubernetes/applications/longhorn-config/backup-target.yaml
+++ b/kubernetes/applications/longhorn-config/backup-target.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: longhorn.io/v1beta2
+kind: BackupTarget
+metadata:
+  name: default
+  namespace: longhorn-system
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
+spec:
+  backupTargetURL: s3://toof-longhorn-backup@us-east-1/
+  credentialSecret: longhorn-backup-r2
+  pollInterval: 5m0s

--- a/kubernetes/applications/longhorn-config/external-secret.yaml
+++ b/kubernetes/applications/longhorn-config/external-secret.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: longhorn-backup-r2-external-secret
+  namespace: longhorn-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-backup-r2
+    template:
+      type: Opaque
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .access_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .secret_access_key }}"
+        AWS_ENDPOINTS: "{{ .endpoints }}"
+  data:
+    - secretKey: access_key_id
+      remoteRef:
+        key: longhorn-backup-r2-access-key-id
+    - secretKey: secret_access_key
+      remoteRef:
+        key: longhorn-backup-r2-secret-access-key
+    - secretKey: endpoints
+      remoteRef:
+        key: longhorn-backup-r2-endpoints

--- a/kubernetes/applications/longhorn-config/recurring-jobs.yaml
+++ b/kubernetes/applications/longhorn-config/recurring-jobs.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: db-6h
+  namespace: longhorn-system
+spec:
+  cron: "0 */6 * * *"
+  task: backup
+  groups:
+    - db-6h
+  retain: 4
+  concurrency: 2
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: daily
+  namespace: longhorn-system
+spec:
+  cron: "0 18 * * *"
+  task: backup
+  groups:
+    - daily
+  retain: 7
+  concurrency: 2

--- a/kubernetes/applications/obsidian/obsidian.yaml
+++ b/kubernetes/applications/obsidian/obsidian.yaml
@@ -24,6 +24,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: obsidian-config
   namespace: obsidian
+  labels:
+    recurring-job-group.longhorn.io/daily: enabled
 spec:
   accessModes:
     - ReadWriteOnce

--- a/kubernetes/applications/openclaw/openclaw.yaml
+++ b/kubernetes/applications/openclaw/openclaw.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: openclaw-state
   namespace: openclaw
+  labels:
+    recurring-job-group.longhorn.io/daily: enabled
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: longhorn

--- a/kubernetes/applications/palworld/palworld.yaml
+++ b/kubernetes/applications/palworld/palworld.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: palworld-data
   namespace: palworld
+  labels:
+    recurring-job-group.longhorn.io/daily: enabled
 spec:
   accessModes:
     - ReadWriteOnce

--- a/kubernetes/applications/shisha-log/db.yaml
+++ b/kubernetes/applications/shisha-log/db.yaml
@@ -53,6 +53,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: postgres-data
+        labels:
+          recurring-job-group.longhorn.io/db-6h: enabled
+          recurring-job-group.longhorn.io/daily: enabled
       spec:
         accessModes:
           - ReadWriteOnce

--- a/terraform/cloudflare_r2.tf
+++ b/terraform/cloudflare_r2.tf
@@ -1,0 +1,18 @@
+resource "cloudflare_r2_bucket" "longhorn_backup" {
+  account_id = var.cloudflare_account_id
+  name       = "toof-longhorn-backup"
+  location   = "apac"
+}
+
+resource "google_secret_manager_secret" "longhorn_backup_r2_endpoints" {
+  secret_id = "longhorn-backup-r2-endpoints"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "longhorn_backup_r2_endpoints" {
+  secret      = google_secret_manager_secret.longhorn_backup_r2_endpoints.id
+  secret_data = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
+}


### PR DESCRIPTION
## 概要

Longhorn の永続ボリュームを Cloudflare R2 に自動バックアップする構成を追加します。

- **R2 バケット + エンドポイント URL シークレットは Terraform で作成**(`terraform/cloudflare_r2.tf`)
- `BackupTarget` (name: `default`) を R2 の S3-compatible エンドポイントに向ける
- 2 種類の `RecurringJob`:
  - **`db-6h`**: 6時間ごと、retain 4(直近24時間)
  - **`daily`**: 03:00 JST(UTC 18:00)、retain 7(1週間)
- R2 認証情報は external-secrets 経由で GCP Secret Manager から取得
- 対象 PVC は `recurring-job-group.longhorn.io/<group>: enabled` ラベルでオプトイン

## バックアップ対象

| PVC | グループ | 理由 |
|---|---|---|
| `apple-health/influxdb-data-*` | db-6h + daily | 健康データ DB |
| `bbs/postgres-pvc` | db-6h + daily | 掲示板 DB |
| `dawarich/postgres-data-*` | db-6h + daily | 位置情報 DB |
| `immich/postgres-data-*` | db-6h + daily | 写真メタデータ DB |
| `shisha-log/postgres-data-*` | db-6h + daily | ログ DB |
| `dawarich/dawarich-data` | daily | 位置情報インポート |
| `immich/immich-library` | daily | 写真本体(50Gi) |
| `obsidian/obsidian-config` | daily | ノート |
| `openclaw/openclaw-state` | daily | 監視状態 |
| `palworld/palworld-data` | daily | ゲームセーブ |
| `dev-vm/dev-home` | daily | 開発 VM home |

## 除外

- `monitoring/prometheus-*` — メトリクス(失って可)
- `dawarich/redis-data-*` — キャッシュ
- `arc-runners/arc-dotfiles-nix` — Nix ビルドキャッシュ
- `default/pvc-longhorn-test3` — テスト用

## マージ後の手動作業

1. **HCP Terraform apply 完了確認**
   - `cloudflare_r2_bucket.longhorn_backup` と `google_secret_manager_secret.longhorn_backup_r2_endpoints` が作成されること

2. **R2 S3 API トークン発行(Cloudflare ダッシュボード)**
   - R2 > Manage R2 API Tokens > Create API token
   - Permissions: **Object Read & Write**
   - Bucket: `toof-longhorn-backup` に限定
   - 発行された **Access Key ID** / **Secret Access Key** を控える

3. **GCP Secret Manager に認証情報を登録**(手動、値のみ)
   ```
   longhorn-backup-r2-access-key-id      # R2 Access Key ID
   longhorn-backup-r2-secret-access-key  # R2 Secret Access Key
   ```
   ※ `longhorn-backup-r2-endpoints` は Terraform が自動で作成・値投入します

4. **既存 StatefulSet/DV 由来の PVC にラベル付与**
   `volumeClaimTemplates` の変更は既存 PVC には反映されないため:
   ```bash
   for pvc in \
     "apple-health influxdb-data-influxdb-0 db-6h,daily" \
     "dawarich postgres-data-postgres-0 db-6h,daily" \
     "immich postgres-data-postgres-0 db-6h,daily" \
     "shisha-log postgres-data-postgres-0 db-6h,daily" \
     "dev-vm dev-root daily"
   do
     set -- $pvc
     ns=$1; name=$2; groups=$3
     for g in ${groups//,/ }; do
       kubectl label pvc -n "$ns" "$name" "recurring-job-group.longhorn.io/$g=enabled" --overwrite
     done
   done
   ```

5. **動作確認**
   - `kubectl get backuptargets.longhorn.io -n longhorn-system default` → `AVAILABLE=true`
   - Longhorn UI で最初のバックアップを手動実行して疎通確認

## コスト見積もり

- R2 ストレージ: 増分バックアップで概ね 100–200 GiB → **~\$3/月**
- Class A/B operations: 微々たる額
- エグレス: 無料(復元試験も安心)

## 参考

- Longhorn CRD `longhorn.io/v1beta2` は 1.12 の storage version(kubectl 確認済み)
- ESO v1 template engine v2 の bare \`{{ .key }}\` 構文を使用(既存 repo パターンと同じ)
- Cloudflare provider v5 の R2 bucket location は小文字(`apac`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)