### PR TITLE
Add CloudNativePG Cluster for shisha-log alongside existing StatefulSet

### DIFF
--- a/kubernetes/applications/shisha-log/postgres-cluster.yaml
+++ b/kubernetes/applications/shisha-log/postgres-cluster.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-app-external-secret
+  namespace: shisha-log
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: postgres-app-secret
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: shisha_log
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: shisha-log-db-password
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: shisha-log
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-minimal-trixie
+  storage:
+    size: 5Gi
+    storageClass: longhorn
+  bootstrap:
+    initdb:
+      database: shisha_log
+      owner: shisha_log
+      secret:
+        name: postgres-app-secret
+      dataChecksums: true
+      postInitSQL:
+        - |
+          DO $$ BEGIN
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+              CREATE ROLE service_role NOLOGIN;
+            END IF;
+          END $$
+        - GRANT service_role TO shisha_log WITH ADMIN OPTION
+      import:
+        type: microservice
+        databases:
+          - shisha_log
+        source:
+          externalCluster: old-postgres
+  externalClusters:
+    - name: old-postgres
+      connectionParameters:
+        host: postgres
+        user: shisha_log
+        dbname: shisha_log
+        sslmode: disable
+      password:
+        name: postgres-secret
+        key: POSTGRES_PASSWORD


### PR DESCRIPTION
## 概要

shisha-log の Postgres を CloudNativePG (CNPG) Cluster に移行する 2 段階のうちの **1 段目**(旧 StatefulSet と並走)。マージ後に手動で import 完了を確認し、GCP Secret Manager の DATABASE_URL を `postgres` → `postgres-rw` に書き換え、アプリを rollout → その後に別 PR で旧 StatefulSet/Service/PVC を削除する。

- CNPG Cluster `postgres`(instances 1, storage 5Gi longhorn, image `ghcr.io/cloudnative-pg/postgresql:18.4-minimal-trixie`)を追加。
- `bootstrap.initdb.import`(microservice mode)で旧 `postgres` Service を `externalCluster` として論理コピーする。
- ブートストラップ用の basic-auth `postgres-app-secret` は既存 GCP Secret `shisha-log-db-password` を再利用。旧 DB と同じパスワードなので DATABASE_URL の書き換えはホスト部分だけで済む。
- `postInitSQL` で `service_role`(migration Job の schema.sql が期待するロール)を先に作成しておく(冪等)。
- 既存 `db.yaml` は本 PR では触らない。切り替え完了確認後に別 PR で削除。

## マージ後のカットオーバー手順(手動)

1. ArgoCD で shisha-log Application が Synced/Healthy を確認。
2. `kubectl -n shisha-log get cluster postgres` が `Cluster in healthy state` になり、`kubectl -n shisha-log logs job/postgres-1-initdb` で pg_dump/pg_restore が成功していることを確認。
3. 新 DB に接続して行数チェック: `kubectl -n shisha-log exec -it postgres-1 -c postgres -- psql -U shisha_log -c "SELECT count(*) FROM public.shisha_sessions;"`
4. shisha-log / postgrest をスケール 0(ダウンタイム開始)。
5. GCP Secret Manager の `shisha-log-database-url` を `@postgres:5432/` → `@postgres-rw:5432/` に更新(または新バージョン追加)。
6. `kubectl -n shisha-log annotate externalsecret shisha-log-external-secret postgrest-external-secret force-sync=$(date +%s) --overwrite` で ES を即時同期。
7. shisha-log / postgrest を rollout。
8. ヘルスチェックし、次の PR(旧 StatefulSet/Service/ExternalSecret/PVC 削除)を出す。

## Test plan

- [x] `kubectl apply --dry-run=client` で構文パス
- [x] opencode レビュー済み
- [ ] マージ後: Cluster が Healthy、import Job 成功、行数一致
- [ ] カットオーバー後: shisha-api.toof.jp 応答、PostgREST 応答

🤖 Generated with [Claude Code](https://claude.com/claude-code)