### PR TITLE
feat(immich): expose immich-proxy via NodePort for LAN uploads

### DIFF
--- a/kubernetes/applications/immich/proxy.yaml
+++ b/kubernetes/applications/immich/proxy.yaml
@@ -126,12 +126,14 @@ metadata:
   labels:
     app: immich-proxy
 spec:
+  type: NodePort
   selector:
     app: immich-proxy
   ports:
     - name: http
       port: 8080
       targetPort: http
+      nodePort: 30283
     - name: metrics
       port: 4040
       targetPort: metrics


### PR DESCRIPTION
## 概要
`immich-proxy` Service に `type: NodePort` と `nodePort: 30283` を付与し、Cloudflare Tunnel を経由しない LAN/Tailscale 経路でのアップロードを可能にする。

## 背景
- `immich-server` に `[Api:FileUploadInterceptor] Request error while uploading file, cleaning up / Error: aborted` が頻発(直近 48h で 28 件)
- 同時刻に `controlled-cloudflared-connector` 側で `Incoming request ended abruptly: context canceled` (ingressRule=18) が出ており、Cloudflare Tunnel が動画アップロード途中で切断していることを示唆
- Cloudflare edge の proxied upload 上限(Free/Pro プランで 100 MB)に動画サイズが引っかかっているのが原因
- Immich 本体は TUS/chunked upload 未実装(discussion #22762 等)なため、経路側で対処する必要がある

## 対処
`immich-proxy` を NodePort として nuc (Tailscale IP `100.112.113.18`) 経由でも到達できるようにする。iOS アプリの `Settings → Networking → Automatic URL switching` で以下を設定して LAN 上では CF Tunnel をバイパスさせる想定:

- Local URL: `http://100.112.113.18:30283`
- External URL: `https://photo.toof.jp` (据え置き)

`immich-proxy` Deployment は `nodeSelector: kubernetes.io/hostname: zen2` のままだが、NodePort は kube-proxy が全ノードで受けて Pod まで転送するので、nuc:30283 に来た通信でも問題なく zen2 の Pod に届く。既存の nginx (`client_max_body_size 0`, timeout 600s) をそのまま通るので Web UI と同じ挙動になる。

## 影響
- 追加の Service ポートを開けるだけで、CF Tunnel 経由の既存フロー (`photo.toof.jp`) には影響なし
- metrics ポート (4040) は ClusterIP のまま(nodePort 未指定)

## Test plan
- [ ] `kubectl get svc -n immich immich-proxy` で `NodePort` かつ `30283` になっているか確認
- [ ] `curl -H "Host: photo.toof.jp" http://100.112.113.18:30283/healthz` が 200 を返すか
- [ ] iOS アプリの Local URL を上記に設定し、100 MB 超動画がアップロードできることを確認
- [ ] 従来の `photo.toof.jp` からのアクセスも問題ないか