### PR TITLE
Fix shisha-log CNPG postInitSQL dollar-quoting

### DIFF
--- a/kubernetes/applications/shisha-log/postgres-cluster.yaml
+++ b/kubernetes/applications/shisha-log/postgres-cluster.yaml
@@ -40,12 +40,7 @@ spec:
         name: postgres-app-secret
       dataChecksums: true
       postInitSQL:
-        - |
-          DO $$ BEGIN
-            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
-              CREATE ROLE service_role NOLOGIN;
-            END IF;
-          END $$
+        - CREATE ROLE service_role NOLOGIN
         - GRANT service_role TO shisha_log WITH ADMIN OPTION
       import:
         type: microservice


### PR DESCRIPTION
## 概要

PR #213 でブートストラップした shisha-log の CNPG Cluster が `postgres-1-import` Job で `syntax error at or near "$"` を起こしてインポートに失敗している。

原因: CNPG の postInitSQL 実行時に `DO $$ ... END $$` の `$$` が `$` に潰されており、psql に渡る時点で構文エラーになっている。

修正: `DO $$ ... END $$` の冪等ブロックを素の `CREATE ROLE service_role NOLOGIN` に置き換え。postInitSQL は fresh initdb 時にしか走らない(bootstrap リトライは pgdata を再作成する)ので冪等化は不要。

## 検証

Job のログで `postgres-1-import` 再起動が pgdata を毎回リネームしていることを確認済み(`pgdataNewName":"/var/lib/postgresql/data/pgdata_20260721T011314Z"`)。したがってバブル `CREATE ROLE` は 2 度実行されない。

## マージ後の確認

1. ArgoCD sync → `postgres-1-import` Job が Completed になるのを待つ
2. `kubectl get cluster -n shisha-log postgres` の `STATUS: Cluster in healthy state` を確認
3. `kubectl -n shisha-log exec postgres-1 -- psql -U postgres shisha_log -c "\dt"` で旧 DB からのインポート内容を確認
4. 以降は PR #213 に書いたカットオーバー手順(GCP secret `shisha-log-database-url` のホストを `postgres` → `postgres-rw`)へ

🤖 Generated with [Claude Code](https://claude.com/claude-code)