### PR TITLE
fix(bbs): stop rotating postgres password every hour

### DIFF
--- a/kubernetes/applications/bbs/external-secret.yaml
+++ b/kubernetes/applications/bbs/external-secret.yaml
@@ -76,12 +76,10 @@ spec:
         POSTGRES_PASSWORD: "{{ .password }}"
         DATABASE_URL: >-
           postgresql://user:{{ .password }}@postgres:5432/bbs
-  dataFrom:
-    - sourceRef:
-        generatorRef:
-          apiVersion: generators.external-secrets.io/v1alpha1
-          kind: ClusterGenerator
-          name: password
+  data:
+    - secretKey: password
+      remoteRef:
+        key: bbs-postgres-password
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret


### PR DESCRIPTION
## Root cause

The \`postgres-external-secret\` was sourcing its value from the \`password\` \`ClusterGenerator\` with \`refreshInterval: 1h\`. Each reconcile generates a fresh random 42-char string — but the underlying Postgres user password only gets set once, when the data dir is first initialized. Every rotation therefore desyncs the two:

- pods that captured an older matching value stay working
- any pod that (re)starts after a rotation reads the new value and gets \`password authentication failed for user "user"\`

That's why \`discord-webhook\` has been CrashLoopBackOff-ing for 30+ restarts in the last 13 days, and why today's rollout onto the new nuc node made \`discord-webhook\`, \`fetch-post-discord-bot\`, and \`search-crawler\` all fail immediately — they got fresh pods, fresh env, and no longer matched the DB.

## Fix

Switch \`postgres-external-secret\` to fetch \`password\` from GCP Secret Manager (key \`bbs-postgres-password\`), matching the pattern used by the other ExternalSecrets in the same file.

## Post-merge steps (required)

1. Set \`bbs-postgres-password\` in GCP Secret Manager to a chosen value P
2. \`ALTER USER "user" WITH PASSWORD 'P';\` on \`postgres-0\` in the bbs namespace so the DB matches
3. external-secrets will rewrite \`postgres-secret\` on next reconcile; the affected pods (\`discord-webhook\`, \`fetch-post-discord-bot\`, \`search-crawler\`, \`postgres-0\`) will pick up the new value on next restart

## Related — not fixed here

The same broken pattern (generatorRef → \`password\`) is also used by:
- \`applications/dawarich/external-secret.yaml\` (2 occurrences)
- \`applications/immich/external-secret.yaml\`
- \`applications/openclaw/external-secret.yaml\`
- \`applications/monitoring/grafana-admin-secret.yaml\`

Each carries the same drift risk and should get an equivalent follow-up PR.