### PR TITLE
fix(immich,openclaw): stop rotating password-generator secrets hourly

### DIFF
--- a/kubernetes/applications/immich/external-secret.yaml
+++ b/kubernetes/applications/immich/external-secret.yaml
@@ -17,9 +17,7 @@ spec:
         POSTGRES_USER: immich
         POSTGRES_DB: immich
         POSTGRES_PASSWORD: "{{ .password }}"
-  dataFrom:
-    - sourceRef:
-        generatorRef:
-          apiVersion: generators.external-secrets.io/v1alpha1
-          kind: ClusterGenerator
-          name: password
+  data:
+    - secretKey: password
+      remoteRef:
+        key: immich-postgres-password

--- a/kubernetes/applications/openclaw/external-secret.yaml
+++ b/kubernetes/applications/openclaw/external-secret.yaml
@@ -50,9 +50,7 @@ spec:
       type: Opaque
       data:
         OPENCLAW_GATEWAY_TOKEN: "{{ .password }}"
-  dataFrom:
-    - sourceRef:
-        generatorRef:
-          apiVersion: generators.external-secrets.io/v1alpha1
-          kind: ClusterGenerator
-          name: password
+  data:
+    - secretKey: password
+      remoteRef:
+        key: openclaw-gateway-token


### PR DESCRIPTION
## Summary
Follow-up to #218. Two more \`ExternalSecret\`s use the \`password\` \`ClusterGenerator\` with the default periodic refresh (no \`refreshPolicy: CreatedOnce\`), so their values change on every reconcile while the downstream systems keep the original — same drift bug.

Broken:
- \`immich/postgres-external-secret\` — directly responsible for \`immich-server\` CrashLoopBackOff with \`code: 28P01, routine: auth_failed\` observed today
- \`openclaw/openclaw-gateway-token-external-secret\` — token drifts vs whatever verifies it

Not touched (already use \`refreshPolicy: CreatedOnce\` → value pinned at first sync):
- \`dawarich/postgres-external-secret\`, \`dawarich/dawarich-external-secret\`
- \`monitoring/grafana-admin-secret\`

## Post-merge steps (per broken app)
1. Set the GCP Secret Manager key to a chosen value P
2. Update the downstream to accept P
   - immich: \`ALTER USER immich WITH PASSWORD 'P';\`
   - openclaw: restart consumers so they pick up P (no persistent state)
3. Force ExternalSecret refresh; restart affected pods

## Test plan
- [ ] merge, wait for argocd sync
- [ ] confirm both ExternalSecrets show \`data\` (not \`dataFrom\`) in the cluster
- [ ] complete the per-app steps above
- [ ] \`immich-server\` reaches Running; \`openclaw\` accepts requests