### PR TITLE
docs(openclaw): gateway token now comes from GCP Secret Manager

### DIFF
--- a/kubernetes/applications/openclaw/README.md
+++ b/kubernetes/applications/openclaw/README.md
@@ -16,11 +16,12 @@ The official Docker image does not bundle the Vertex provider, but no manual ins
 
 ## Secret Values
 
-Create this secret in GCP Secret Manager (project `toof-infra`):
+Create these secrets in GCP Secret Manager (project `toof-infra`):
 
 - `openclaw-discord-bot-token`: Discord bot token (see below)
+- `openclaw-gateway-token`: any random string used to authenticate to the Control UI
 
-The gateway auth token (`OPENCLAW_GATEWAY_TOKEN`) is generated in-cluster by the `password` ClusterGenerator. Read it with:
+Read the current value of the gateway token (mirrored into the cluster as `openclaw-gateway-token-secret`) with:
 
 ```sh
 kubectl -n openclaw get secret openclaw-gateway-token-secret \


### PR DESCRIPTION
## Summary
Follow-up doc update to #219, which moved \`openclaw-gateway-token-external-secret\` off the in-cluster \`password\` \`ClusterGenerator\`.

The old README section described how to read a token that had been randomly generated in-cluster; that flow no longer applies. Now users need to set \`openclaw-gateway-token\` in GCP Secret Manager (project \`toof-infra\`) themselves, and external-secrets mirrors that value into \`openclaw-gateway-token-secret\`.

## Test plan
- [ ] read renders correctly on GitHub
- [ ] instructions match what actually happens now:
  - \`gcloud secrets create openclaw-gateway-token ...\` → external-secrets picks it up → \`kubectl get secret openclaw-gateway-token-secret\` returns the same value