### PR TITLE
Add CloudNativePG Cluster for dawarich alongside existing StatefulSet

### DIFF
--- a/kubernetes/applications/dawarich/postgres-cluster.yaml
+++ b/kubernetes/applications/dawarich/postgres-cluster.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-app-external-secret
+  namespace: dawarich
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: postgres-app-secret
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: dawarich
+        password: "{{ .password }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: ClusterGenerator
+          name: password
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: dawarich
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgis:17-3.5-9
+  storage:
+    size: 10Gi
+    storageClass: longhorn
+  bootstrap:
+    initdb:
+      database: dawarich
+      owner: dawarich
+      secret:
+        name: postgres-app-secret
+      dataChecksums: true
+      import:
+        type: microservice
+        databases:
+          - dawarich
+        source:
+          externalCluster: old-postgres
+  externalClusters:
+    - name: old-postgres
+      connectionParameters:
+        host: postgres
+        user: dawarich
+        dbname: dawarich
+        sslmode: disable
+      password:
+        name: postgres-secret
+        key: POSTGRES_PASSWORD
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres-cnpg
+  namespace: dawarich
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: postgres
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: dawarich
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/kubernetes/applications/dawarich/postgres.yaml
+++ b/kubernetes/applications/dawarich/postgres.yaml
@@ -106,6 +106,9 @@ spec:
         - podSelector:
             matchLabels:
               app: dawarich
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: postgres
       ports:
         - protocol: TCP
           port: 5432


### PR DESCRIPTION
## 概要

CNPG 移行 Phase 1 / 2。dawarich (Rails + Sidekiq + PostGIS) の DB を CNPG に移行するため、まず CNPG Cluster を旧 StatefulSet と併存させて microservice import で論理コピーする。

## 変更

- **`postgres-cluster.yaml` 新規**:
  - `postgres-app-external-secret`: `refreshPolicy: CreatedOnce` の ClusterGenerator (password) 生成の basic-auth secret
  - CNPG `Cluster/postgres`: `ghcr.io/cloudnative-pg/postgis:17-3.5-9` (旧: `postgis/postgis:17-3.5-alpine`)、10Gi Longhorn、`bootstrap.initdb.import` で旧 postgres から dawarich DB を論理コピー
  - `NetworkPolicy/postgres-cnpg`: `app: dawarich` からの CNPG ポッド (`cnpg.io/cluster: postgres`) 5432/TCP 許可
- **`postgres.yaml` の旧 NP を patch**: 一回限りの import のため CNPG ポッドを追加 ingress 元に

## 事前確認済み

- 旧 DB extension: postgis 3.5.7 / postgis_topology / postgis_tiger_geocoder / fuzzystrmatch / pgcrypto — CNPG postgis イメージに全て含まれる
- 旧 StatefulSet の `POSTGRES_USER: dawarich`(externalCluster.user と一致)
- Namespace に default-deny egress なし(CNPG → 旧 postgres の egress は素通り)
- `postgres-secret` の `POSTGRES_PASSWORD` key は既存 ES 経由で存在

## マージ後の手動カットオーバー(Phase 2 PR で自動化予定だが検証は手動)

1. `kubectl get cluster postgres -n dawarich` が `Cluster in healthy state` になるのを待つ
2. `kubectl get jobs postgres-1-import -n dawarich` が Complete になるのを待つ
3. 旧・新 DB の主要テーブル行数比較(points, tracks, users, imports 等)
4. カットオーバー PR (Phase 2) で ConfigMap の `DATABASE_HOST: postgres` → `postgres-rw`、dawarich.yaml の `DATABASE_PASSWORD` secretKeyRef を `postgres-app-secret.password` に、`db.yaml` (旧 postgres.yaml) を削除、CNPG Cluster から `bootstrap.initdb.import` と `externalClusters` を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)