### PR TITLE
Add CloudNativePG Cluster for immich alongside existing StatefulSet

### DIFF
--- a/kubernetes/applications/immich/postgres-cluster.yaml
+++ b/kubernetes/applications/immich/postgres-cluster.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-app-external-secret
+  namespace: immich
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: postgres-app-secret
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: immich
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: immich-postgres-password
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: immich
+spec:
+  instances: 1
+  imageName: ghcr.io/immich-app/postgres:16-vectorchord0.4.3-pgvectors0.2.0
+  postgresql:
+    shared_preload_libraries:
+      - vchord.so
+  affinity:
+    nodeSelector:
+      kubernetes.io/hostname: zen2
+  storage:
+    size: 10Gi
+    storageClass: longhorn
+  bootstrap:
+    initdb:
+      database: immich
+      owner: immich
+      secret:
+        name: postgres-app-secret
+      dataChecksums: true
+      import:
+        type: microservice
+        databases:
+          - immich
+        source:
+          externalCluster: old-postgres
+  externalClusters:
+    - name: old-postgres
+      connectionParameters:
+        host: postgres
+        user: immich
+        dbname: immich
+        sslmode: disable
+      password:
+        name: postgres-secret
+        key: POSTGRES_PASSWORD


### PR DESCRIPTION
## 概要

CNPG 移行 Phase 1 / 2。immich の DB を CNPG に移行するため CNPG Cluster を旧 StatefulSet と併存させて microservice import で論理コピーする。

## 変更

`postgres-cluster.yaml` 新規:
- `postgres-app-external-secret`: 既存の GCP secret `immich-postgres-password` から basic-auth secret を生成(旧 `postgres-secret` と同じパスワード → カットオーバーでパスワード変更不要)
- CNPG `Cluster/postgres`: `ghcr.io/immich-app/postgres:16-vectorchord0.4.3-pgvectors0.2.0`(現行と同一)、10Gi Longhorn、zen2 affinity、`shared_preload_libraries: [vchord.so]`、`bootstrap.initdb.import` で旧 postgres から immich DB を論理コピー

## 事前確認済み

- DB サイズ: 313 MB
- 旧 DB extension: cube, earthdistance, pg_trgm, plpgsql, unaccent, uuid-ossp, vchord 0.4.3, vector 0.8.1 — 現行イメージに全て含まれる(同一イメージ使用)
- `immich-postgres-password` は GCP から取得(refreshInterval 1h、値は不変)
- immich namespace に NetworkPolicy 無し、追加不要
- 旧 StatefulSet の `POSTGRES_USER: immich`(externalCluster.user と一致)

## opencode レビュー時のメモ

- `vchord.so` → `vchord` への変更提案は却下: VectorChord 公式ドキュメントおよび TensorChord CNPG サンプルは `.so` 付き表記を使用。PostgreSQL の shared_preload_libraries は名前に `.so` を含む場合 literal filename として扱われるため両方動作するが公式表記に従う。
- pgvector は shared_preload_libraries 不要(型/演算子提供の通常拡張)

## マージ後の手動カットオーバー(別 PR)

1. `kubectl get cluster postgres -n immich` が healthy になるのを待つ
2. `postgres-1-import` Job Complete 確認
3. asset 数比較 (`SELECT count(*) FROM assets`)
4. カットオーバー PR: `immich.yaml` の `DB_HOSTNAME: postgres` → `postgres-rw`、`postgres-cluster.yaml` から `bootstrap.initdb.import` と `externalClusters` を削除、`postgres.yaml` (旧 StatefulSet) を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)