### PR TITLE
Fold auth0 MCP clients into a for_each loop

### DIFF
--- a/terraform/mcp.tf
+++ b/terraform/mcp.tf
@@ -1,23 +1,32 @@
 locals {
-  obsidian_mcp_hostname = "obsidian-mcp.${var.domain}"
-  obsidian_mcp_url      = "https://${local.obsidian_mcp_hostname}"
-  immich_mcp_hostname   = "immich-mcp.${var.domain}"
-  immich_mcp_url        = "https://${local.immich_mcp_hostname}"
+  mcp_clients = {
+    "obsidian-mcp" = {
+      description = "Claude Mobile remote MCP connector for the Obsidian vault."
+    }
+    "immich-mcp" = {
+      description = "Claude remote MCP connector for the Immich photo library."
+    }
+    "apple-health-mcp" = {
+      description = "Claude remote MCP connector for the Apple Health InfluxDB data."
+    }
+    "beancount-mcp" = {
+      description = "Claude remote MCP connector for the Beancount ledger."
+    }
+    "dawarich-mcp" = {
+      description = "Claude remote MCP connector for the Dawarich location history."
+    }
+  }
 
-  apple_health_mcp_hostname = "apple-health-mcp.${var.domain}"
-  apple_health_mcp_url      = "https://${local.apple_health_mcp_hostname}"
-
-  beancount_mcp_hostname = "beancount-mcp.${var.domain}"
-  beancount_mcp_url      = "https://${local.beancount_mcp_hostname}"
-
-  dawarich_mcp_hostname = "dawarich-mcp.${var.domain}"
-  dawarich_mcp_url      = "https://${local.dawarich_mcp_hostname}"
+  mcp_hostnames = { for k, _ in local.mcp_clients : k => "${k}.${var.domain}" }
+  mcp_urls      = { for k, h in local.mcp_hostnames : k => "https://${h}" }
 }
 
-resource "auth0_client" "obsidian_mcp" {
-  name        = "obsidian-mcp"
+resource "auth0_client" "mcp" {
+  for_each = local.mcp_clients
+
+  name        = each.key
   app_type    = "regular_web"
-  description = "Claude Mobile remote MCP connector for the Obsidian vault."
+  description = each.value.description
 
   callbacks = [
     "https://claude.ai/api/mcp/auth_callback",
@@ -34,185 +43,119 @@ resource "auth0_client" "obsidian_mcp" {
   oidc_conformant = true
 }
 
-resource "auth0_client_credentials" "obsidian_mcp" {
-  client_id             = auth0_client.obsidian_mcp.id
+resource "auth0_client_credentials" "mcp" {
+  for_each = local.mcp_clients
+
+  client_id             = auth0_client.mcp[each.key].id
   authentication_method = "client_secret_post"
 }
 
 # Claude sends the RFC 8707 resource parameter as the canonical origin URI
 # with a trailing slash; Auth0 matches API identifiers by exact string, so
 # the identifier must carry the slash too.
-resource "auth0_resource_server" "obsidian_mcp" {
-  name                 = "obsidian-mcp-api"
-  identifier           = "${local.obsidian_mcp_url}/"
+resource "auth0_resource_server" "mcp" {
+  for_each = local.mcp_clients
+
+  name                 = "${each.key}-api"
+  identifier           = "${local.mcp_urls[each.key]}/"
   signing_alg          = "RS256"
   allow_offline_access = true
 }
 
-resource "auth0_resource_server_scopes" "obsidian_mcp" {
-  resource_server_identifier = auth0_resource_server.obsidian_mcp.identifier
+resource "auth0_resource_server_scopes" "mcp" {
+  for_each = local.mcp_clients
+
+  resource_server_identifier = auth0_resource_server.mcp[each.key].identifier
   scopes {
     name        = "mcp:tools"
     description = "MCP tools access"
   }
 }
 
-resource "auth0_client" "immich_mcp" {
-  name        = "immich-mcp"
-  app_type    = "regular_web"
-  description = "Claude remote MCP connector for the Immich photo library."
-
-  callbacks = [
-    "https://claude.ai/api/mcp/auth_callback",
-    "https://claude.com/api/mcp/auth_callback",
-  ]
-
-  allowed_logout_urls = []
-
-  grant_types = [
-    "authorization_code",
-    "refresh_token",
-  ]
-
-  oidc_conformant = true
+# Preserve terraform state across the flat-resource → for_each migration so
+# apply doesn't destroy and recreate these clients (which would rotate their
+# client_ids and break connected Claude instances).
+moved {
+  from = auth0_client.obsidian_mcp
+  to   = auth0_client.mcp["obsidian-mcp"]
+}
+moved {
+  from = auth0_client_credentials.obsidian_mcp
+  to   = auth0_client_credentials.mcp["obsidian-mcp"]
+}
+moved {
+  from = auth0_resource_server.obsidian_mcp
+  to   = auth0_resource_server.mcp["obsidian-mcp"]
+}
+moved {
+  from = auth0_resource_server_scopes.obsidian_mcp
+  to   = auth0_resource_server_scopes.mcp["obsidian-mcp"]
 }
 
-resource "auth0_client_credentials" "immich_mcp" {
-  client_id             = auth0_client.immich_mcp.id
-  authentication_method = "client_secret_post"
+moved {
+  from = auth0_client.immich_mcp
+  to   = auth0_client.mcp["immich-mcp"]
+}
+moved {
+  from = auth0_client_credentials.immich_mcp
+  to   = auth0_client_credentials.mcp["immich-mcp"]
+}
+moved {
+  from = auth0_resource_server.immich_mcp
+  to   = auth0_resource_server.mcp["immich-mcp"]
+}
+moved {
+  from = auth0_resource_server_scopes.immich_mcp
+  to   = auth0_resource_server_scopes.mcp["immich-mcp"]
 }
 
-resource "auth0_resource_server" "immich_mcp" {
-  name                 = "immich-mcp-api"
-  identifier           = "${local.immich_mcp_url}/"
-  signing_alg          = "RS256"
-  allow_offline_access = true
+moved {
+  from = auth0_client.apple_health_mcp
+  to   = auth0_client.mcp["apple-health-mcp"]
+}
+moved {
+  from = auth0_client_credentials.apple_health_mcp
+  to   = auth0_client_credentials.mcp["apple-health-mcp"]
+}
+moved {
+  from = auth0_resource_server.apple_health_mcp
+  to   = auth0_resource_server.mcp["apple-health-mcp"]
+}
+moved {
+  from = auth0_resource_server_scopes.apple_health_mcp
+  to   = auth0_resource_server_scopes.mcp["apple-health-mcp"]
 }
 
-resource "auth0_resource_server_scopes" "immich_mcp" {
-  resource_server_identifier = auth0_resource_server.immich_mcp.identifier
-  scopes {
-    name        = "mcp:tools"
-    description = "MCP tools access"
-  }
+moved {
+  from = auth0_client.beancount_mcp
+  to   = auth0_client.mcp["beancount-mcp"]
+}
+moved {
+  from = auth0_client_credentials.beancount_mcp
+  to   = auth0_client_credentials.mcp["beancount-mcp"]
+}
+moved {
+  from = auth0_resource_server.beancount_mcp
+  to   = auth0_resource_server.mcp["beancount-mcp"]
+}
+moved {
+  from = auth0_resource_server_scopes.beancount_mcp
+  to   = auth0_resource_server_scopes.mcp["beancount-mcp"]
 }
 
-resource "auth0_client" "apple_health_mcp" {
-  name        = "apple-health-mcp"
-  app_type    = "regular_web"
-  description = "Claude remote MCP connector for the Apple Health InfluxDB data."
-
-  callbacks = [
-    "https://claude.ai/api/mcp/auth_callback",
-    "https://claude.com/api/mcp/auth_callback",
-  ]
-
-  allowed_logout_urls = []
-
-  grant_types = [
-    "authorization_code",
-    "refresh_token",
-  ]
-
-  oidc_conformant = true
+moved {
+  from = auth0_client.dawarich_mcp
+  to   = auth0_client.mcp["dawarich-mcp"]
 }
-
-resource "auth0_client_credentials" "apple_health_mcp" {
-  client_id             = auth0_client.apple_health_mcp.id
-  authentication_method = "client_secret_post"
+moved {
+  from = auth0_client_credentials.dawarich_mcp
+  to   = auth0_client_credentials.mcp["dawarich-mcp"]
 }
-
-resource "auth0_resource_server" "apple_health_mcp" {
-  name                 = "apple-health-mcp-api"
-  identifier           = "${local.apple_health_mcp_url}/"
-  signing_alg          = "RS256"
-  allow_offline_access = true
+moved {
+  from = auth0_resource_server.dawarich_mcp
+  to   = auth0_resource_server.mcp["dawarich-mcp"]
 }
-
-resource "auth0_resource_server_scopes" "apple_health_mcp" {
-  resource_server_identifier = auth0_resource_server.apple_health_mcp.identifier
-  scopes {
-    name        = "mcp:tools"
-    description = "MCP tools access"
-  }
-}
-
-resource "auth0_client" "beancount_mcp" {
-  name        = "beancount-mcp"
-  app_type    = "regular_web"
-  description = "Claude remote MCP connector for the Beancount ledger."
-
-  callbacks = [
-    "https://claude.ai/api/mcp/auth_callback",
-    "https://claude.com/api/mcp/auth_callback",
-  ]
-
-  allowed_logout_urls = []
-
-  grant_types = [
-    "authorization_code",
-    "refresh_token",
-  ]
-
-  oidc_conformant = true
-}
-
-resource "auth0_client_credentials" "beancount_mcp" {
-  client_id             = auth0_client.beancount_mcp.id
-  authentication_method = "client_secret_post"
-}
-
-resource "auth0_resource_server" "beancount_mcp" {
-  name                 = "beancount-mcp-api"
-  identifier           = "${local.beancount_mcp_url}/"
-  signing_alg          = "RS256"
-  allow_offline_access = true
-}
-
-resource "auth0_resource_server_scopes" "beancount_mcp" {
-  resource_server_identifier = auth0_resource_server.beancount_mcp.identifier
-  scopes {
-    name        = "mcp:tools"
-    description = "MCP tools access"
-  }
-}
-
-resource "auth0_client" "dawarich_mcp" {
-  name        = "dawarich-mcp"
-  app_type    = "regular_web"
-  description = "Claude remote MCP connector for the Dawarich location history."
-
-  callbacks = [
-    "https://claude.ai/api/mcp/auth_callback",
-    "https://claude.com/api/mcp/auth_callback",
-  ]
-
-  allowed_logout_urls = []
-
-  grant_types = [
-    "authorization_code",
-    "refresh_token",
-  ]
-
-  oidc_conformant = true
-}
-
-resource "auth0_client_credentials" "dawarich_mcp" {
-  client_id             = auth0_client.dawarich_mcp.id
-  authentication_method = "client_secret_post"
-}
-
-resource "auth0_resource_server" "dawarich_mcp" {
-  name                 = "dawarich-mcp-api"
-  identifier           = "${local.dawarich_mcp_url}/"
-  signing_alg          = "RS256"
-  allow_offline_access = true
-}
-
-resource "auth0_resource_server_scopes" "dawarich_mcp" {
-  resource_server_identifier = auth0_resource_server.dawarich_mcp.identifier
-  scopes {
-    name        = "mcp:tools"
-    description = "MCP tools access"
-  }
+moved {
+  from = auth0_resource_server_scopes.dawarich_mcp
+  to   = auth0_resource_server_scopes.mcp["dawarich-mcp"]
 }

--- a/terraform/mcp_outputs.tf
+++ b/terraform/mcp_outputs.tf
@@ -1,14 +1,3 @@
-output "auth0_obsidian_mcp_client_id" {
-  value       = auth0_client.obsidian_mcp.client_id
-  description = "OAuth client ID for the Claude Obsidian MCP connector."
-}
-
-output "auth0_obsidian_mcp_client_secret" {
-  value       = auth0_client_credentials.obsidian_mcp.client_secret
-  description = "OAuth client secret for the Claude Obsidian MCP connector."
-  sensitive   = true
-}
-
 output "auth0_domain" {
   value       = var.auth0_domain
   description = "Auth0 tenant domain."
@@ -24,96 +13,107 @@ output "auth0_obsidian_mcp_jwks_uri" {
   description = "JWKS URI for mcp-gate."
 }
 
+output "auth0_obsidian_mcp_client_id" {
+  value       = auth0_client.mcp["obsidian-mcp"].client_id
+  description = "OAuth client ID for the Claude Obsidian MCP connector."
+}
+
+output "auth0_obsidian_mcp_client_secret" {
+  value       = auth0_client_credentials.mcp["obsidian-mcp"].client_secret
+  description = "OAuth client secret for the Claude Obsidian MCP connector."
+  sensitive   = true
+}
+
 output "obsidian_mcp_resource_uri" {
-  value       = local.obsidian_mcp_url
+  value       = local.mcp_urls["obsidian-mcp"]
   description = "Public URL/resource URI for the Obsidian MCP gateway."
 }
 
 output "obsidian_mcp_audience" {
-  value       = auth0_resource_server.obsidian_mcp.identifier
+  value       = auth0_resource_server.mcp["obsidian-mcp"].identifier
   description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
 }
 
 output "auth0_immich_mcp_client_id" {
-  value       = auth0_client.immich_mcp.client_id
+  value       = auth0_client.mcp["immich-mcp"].client_id
   description = "OAuth client ID for the Claude Immich MCP connector."
 }
 
 output "auth0_immich_mcp_client_secret" {
-  value       = auth0_client_credentials.immich_mcp.client_secret
+  value       = auth0_client_credentials.mcp["immich-mcp"].client_secret
   description = "OAuth client secret for the Claude Immich MCP connector."
   sensitive   = true
 }
 
 output "immich_mcp_resource_uri" {
-  value       = local.immich_mcp_url
+  value       = local.mcp_urls["immich-mcp"]
   description = "Public URL/resource URI for the Immich MCP gateway."
 }
 
 output "immich_mcp_audience" {
-  value       = auth0_resource_server.immich_mcp.identifier
+  value       = auth0_resource_server.mcp["immich-mcp"].identifier
   description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
 }
 
 output "auth0_apple_health_mcp_client_id" {
-  value       = auth0_client.apple_health_mcp.client_id
+  value       = auth0_client.mcp["apple-health-mcp"].client_id
   description = "OAuth client ID for the Claude Apple Health MCP connector."
 }
 
 output "auth0_apple_health_mcp_client_secret" {
-  value       = auth0_client_credentials.apple_health_mcp.client_secret
+  value       = auth0_client_credentials.mcp["apple-health-mcp"].client_secret
   description = "OAuth client secret for the Claude Apple Health MCP connector."
   sensitive   = true
 }
 
 output "apple_health_mcp_resource_uri" {
-  value       = local.apple_health_mcp_url
+  value       = local.mcp_urls["apple-health-mcp"]
   description = "Public URL/resource URI for the Apple Health MCP gateway."
 }
 
 output "apple_health_mcp_audience" {
-  value       = auth0_resource_server.apple_health_mcp.identifier
+  value       = auth0_resource_server.mcp["apple-health-mcp"].identifier
   description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
 }
 
 output "auth0_beancount_mcp_client_id" {
-  value       = auth0_client.beancount_mcp.client_id
+  value       = auth0_client.mcp["beancount-mcp"].client_id
   description = "OAuth client ID for the Claude Beancount MCP connector."
 }
 
 output "auth0_beancount_mcp_client_secret" {
-  value       = auth0_client_credentials.beancount_mcp.client_secret
+  value       = auth0_client_credentials.mcp["beancount-mcp"].client_secret
   description = "OAuth client secret for the Claude Beancount MCP connector."
   sensitive   = true
 }
 
 output "beancount_mcp_resource_uri" {
-  value       = local.beancount_mcp_url
+  value       = local.mcp_urls["beancount-mcp"]
   description = "Public URL/resource URI for the Beancount MCP gateway."
 }
 
 output "beancount_mcp_audience" {
-  value       = auth0_resource_server.beancount_mcp.identifier
+  value       = auth0_resource_server.mcp["beancount-mcp"].identifier
   description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
 }
 
 output "auth0_dawarich_mcp_client_id" {
-  value       = auth0_client.dawarich_mcp.client_id
+  value       = auth0_client.mcp["dawarich-mcp"].client_id
   description = "OAuth client ID for the Claude Dawarich MCP connector."
 }
 
 output "auth0_dawarich_mcp_client_secret" {
-  value       = auth0_client_credentials.dawarich_mcp.client_secret
+  value       = auth0_client_credentials.mcp["dawarich-mcp"].client_secret
   description = "OAuth client secret for the Claude Dawarich MCP connector."
   sensitive   = true
 }
 
 output "dawarich_mcp_resource_uri" {
-  value       = local.dawarich_mcp_url
+  value       = local.mcp_urls["dawarich-mcp"]
   description = "Public URL/resource URI for the Dawarich MCP gateway."
 }
 
 output "dawarich_mcp_audience" {
-  value       = auth0_resource_server.dawarich_mcp.identifier
+  value       = auth0_resource_server.mcp["dawarich-mcp"].identifier
   description = "Expected audience configured for mcp-gate. Requires the tenant's Resource Parameter Compatibility Profile so RFC 8707 resource requests map to this API."
 }


### PR DESCRIPTION
## 概要

5 個の Auth0 MCP OAuth client 定義は `name` と `description` 以外まったく同じだったので、`locals.mcp_clients` map + `for_each` に畳み込みました。合計 265 行 → 133 行 (-132 行)。

## 変更内容

- `terraform/mcp.tf`: 5 セット (client / credentials / resource_server / resource_server_scopes) の flat 定義を `for_each = local.mcp_clients` に統合
- `terraform/mcp_outputs.tf`: 各 output の value 参照を `auth0_client.mcp["obsidian-mcp"]` 等に更新 (output 名・型・sensitive は据え置き、consumers に影響なし)
- `moved{}` ブロックを 20 個 (4 resource type × 5 client) 追加して state を保持

## Terraform apply 想定

`moved{}` により以下は **no-op**:

- `auth0_client.obsidian_mcp` → `auth0_client.mcp["obsidian-mcp"]`
- `auth0_client_credentials.obsidian_mcp` → `auth0_client_credentials.mcp["obsidian-mcp"]`
- `auth0_resource_server.obsidian_mcp` → `auth0_resource_server.mcp["obsidian-mcp"]`
- `auth0_resource_server_scopes.obsidian_mcp` → `auth0_resource_server_scopes.mcp["obsidian-mcp"]`
- (immich-mcp / apple-health-mcp / beancount-mcp / dawarich-mcp も同様)

`client_id` は変わらないので既存の Claude 連携は無影響。

## 検証

- `terraform validate` 通過
- `terraform fmt -check` 通過
- HCP Terraform workspace の plan preview で "20 to be moved, 0 to add/change/destroy" を確認してからマージしてください

## 補足

hostname 派生を `"\${key}.\${var.domain}"` にしたので、map key は `"obsidian-mcp"` (dash 区切り) に統一。旧個別 local (`local.obsidian_mcp_hostname` 等) は他ファイルから参照されていなかったので削除。