### PR TITLE
chore(immich): expand library PVC from 50Gi to 200Gi

### DIFF
--- a/kubernetes/applications/immich/pvc.yaml
+++ b/kubernetes/applications/immich/pvc.yaml
@@ -12,4 +12,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 50Gi
+      storage: 200Gi


### PR DESCRIPTION
## 概要
`immich-library` PVC を 50Gi → 200Gi に拡張する。

## 背景
- `immich-server` のアップロードが `ENOSPC: no space left on device` で失敗している
- PVC が 100% 埋まっている:
  ```
  Filesystem   Size  Used  Avail  Use%   Mounted on
  longhorn-pv  49G   49G   0      100%   /data
  ```
- 内訳: library 40G / encoded-video 5.1G / thumbs 3.8G

## 対処可能性
- StorageClass `longhorn` は `allowVolumeExpansion: true` なのでオンライン拡張可能(Pod 再作成不要)
- zen2 の Longhorn デフォルトディスク: max ~930 GiB / avail ~326 GiB / scheduled ~285 GiB → 200 Gi 割り当てに余裕あり
- Longhorn の daily backup (`recurring-job-group.longhorn.io/daily: enabled`) は R2 に保存される。バックアップ対象サイズは実使用量ベースなので当面のバックアップ増分は小さい

## Test plan
- [ ] ArgoCD sync 後 `kubectl get pvc -n immich immich-library` の CAPACITY が 200Gi
- [ ] `kubectl exec -n immich immich-server-... -- df -h /data` で ~200G に拡張されたことを確認
- [ ] Immich でアップロード再開しエラーが消えることを確認
- [ ] Longhorn UI で当該ボリュームの Replicas が Healthy を維持