### PR TITLE
Add CloudNativePG Cluster for bbs alongside existing StatefulSet

### DIFF
--- a/kubernetes/applications/bbs/postgres-cluster.yaml
+++ b/kubernetes/applications/bbs/postgres-cluster.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-app-external-secret
+  namespace: bbs
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: postgres-app-secret
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: user
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: bbs-postgres-password
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: bbs
+spec:
+  instances: 1
+  imageName: ghcr.io/toof-jp/postgres-bigm:sha-4c22b29
+  postgresql:
+    shared_preload_libraries:
+      - pg_bigm
+  storage:
+    size: 10Gi
+    storageClass: longhorn
+  bootstrap:
+    initdb:
+      database: bbs
+      owner: user
+      secret:
+        name: postgres-app-secret
+      dataChecksums: true
+      import:
+        type: microservice
+        databases:
+          - bbs
+        source:
+          externalCluster: old-postgres
+  externalClusters:
+    - name: old-postgres
+      connectionParameters:
+        host: postgres
+        user: user
+        dbname: bbs
+        sslmode: disable
+      password:
+        name: postgres-secret
+        key: POSTGRES_PASSWORD


### PR DESCRIPTION
## 概要

CNPG 移行 Phase 1 / 2。bbs (Japanese BBS + pg_bigm search) の DB を CNPG に移行するため CNPG Cluster を旧 StatefulSet と併存させて microservice import で論理コピーする。

## 依存

toof-jp/postgres-bigm-docker#5(pg_bigm image を CNPG base に載せ替え)がマージ済み、新 image `sha-4c22b29` publish 済み。

## 変更

`postgres-cluster.yaml` 新規:
- `postgres-app-external-secret`: 既存の GCP secret `bbs-postgres-password` から basic-auth secret 生成(旧 `postgres-secret` と同じパスワード → カットオーバーでパスワード変更不要)
- CNPG `Cluster/postgres`:
  - image `ghcr.io/toof-jp/postgres-bigm:sha-4c22b29`
  - `spec.postgresql.shared_preload_libraries: [pg_bigm]`
  - 10Gi Longhorn(旧と同量、DB 実サイズ 854MB)
  - `bootstrap.initdb.import` で旧 postgres から bbs DB を論理コピー

## 事前確認済み

- 旧 DB extension: pg_bigm 1.2, plpgsql — 新 image は pg_bigm を含む
- 旧 DB `SHOW shared_preload_libraries` = `pg_bigm`(新 spec と一致)
- 旧 StatefulSet の `POSTGRES_USER: user`(externalCluster.user と一致)
- bbs namespace に NetworkPolicy 無し

## マージ後の手動カットオーバー(別 PR)

1. `kubectl get cluster postgres -n bbs` が healthy になるのを待つ
2. `postgres-1-import` Job Complete 確認
3. DB size / 主要テーブル行数比較
4. カットオーバー PR: `external-secret.yaml` の postgres-external-secret template の `DATABASE_URL` のホスト `postgres` → `postgres-rw`、`postgres-cluster.yaml` から `bootstrap.initdb.import` と `externalClusters` 削除、`db.yaml` (旧 StatefulSet + Service + PVC) 削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)