### PR TITLE
feat(terraform): provision R2 API token for Longhorn backup

### DIFF
--- a/terraform/cloudflare_r2.tf
+++ b/terraform/cloudflare_r2.tf
@@ -16,3 +16,43 @@ resource "google_secret_manager_secret_version" "longhorn_backup_r2_endpoints" {
   secret      = google_secret_manager_secret.longhorn_backup_r2_endpoints.id
   secret_data = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
 }
+
+resource "cloudflare_api_token" "longhorn_backup_r2" {
+  name = "longhorn-backup-r2"
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.edge.r2.bucket.${var.cloudflare_account_id}_default_${cloudflare_r2_bucket.longhorn_backup.name}" = "*"
+    })
+    permission_groups = [
+      { id = "6a018a9f2fc74eb6b293b0c548f38b39" }, # Workers R2 Storage Bucket Item Read
+      { id = "2efd5506f9c8494dacb1fa10a3e7d5b6" }, # Workers R2 Storage Bucket Item Write
+    ]
+  }]
+}
+
+resource "google_secret_manager_secret" "longhorn_backup_r2_access_key_id" {
+  secret_id = "longhorn-backup-r2-access-key-id"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "longhorn_backup_r2_access_key_id" {
+  secret      = google_secret_manager_secret.longhorn_backup_r2_access_key_id.id
+  secret_data = cloudflare_api_token.longhorn_backup_r2.id
+}
+
+resource "google_secret_manager_secret" "longhorn_backup_r2_secret_access_key" {
+  secret_id = "longhorn-backup-r2-secret-access-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "longhorn_backup_r2_secret_access_key" {
+  secret      = google_secret_manager_secret.longhorn_backup_r2_secret_access_key.id
+  secret_data = sha256(cloudflare_api_token.longhorn_backup_r2.value)
+}


### PR DESCRIPTION
## 概要
`toof-longhorn-backup` R2 バケット向けの Cloudflare API トークンと、S3 互換認証情報を GCP Secret Manager へ格納する Terraform を追加。

## 背景
- ArgoCD の `longhorn-system` Application が Degraded
- `ExternalSecret/longhorn-system/longhorn-backup-r2-external-secret` が `SecretSyncedError`:
  ```
  Message: could not get secret data from provider
  Event:   error processing spec.data[0] (key: longhorn-backup-r2-access-key-id):
           unable to access Secret from SecretManager Client: Secret does not exist
  ```
- 既存 `terraform/cloudflare_r2.tf` は `longhorn-backup-r2-endpoints` しか GCP Secret Manager に登録しておらず、
  ExternalSecret が要求する `access-key-id` / `secret-access-key` が存在しないため R2 backup が起動していない

## 対処
Cloudflare API トークンをバケットスコープで発行し、そこから S3 互換の access_key_id / secret_access_key を派生して Secret Manager に投入する:

- `access_key_id`   = `cloudflare_api_token.longhorn_backup_r2.id`
- `secret_access_key` = `sha256(cloudflare_api_token.longhorn_backup_r2.value)`

これは [Cloudflare R2 公式ドキュメント](https://developers.cloudflare.com/r2/api/tokens/) 記載の派生方法で、jsr-io など OSS の本番 Terraform でも同じパターン。

## 実装メモ
- 権限は `Workers R2 Storage Bucket Item Read/Write` のみに限定(`com.cloudflare.edge.r2.bucket.${account}_default_toof-longhorn-backup` スコープ)
- Permission group ID は本来 `cloudflare_api_token_permission_groups_list` データソースで引きたいが、当該エンドポイント (`/user/tokens/permission_groups`) は **user-level 認証** が必要で、workspace の API トークンでは 403 になる。ID は Cloudflare が公開しており安定しているのでハードコード

## Plan 結果
```
Plan: 5 to add, 0 to change, 0 to destroy.
  + cloudflare_api_token.longhorn_backup_r2
  + google_secret_manager_secret.longhorn_backup_r2_access_key_id
  + google_secret_manager_secret_version.longhorn_backup_r2_access_key_id
  + google_secret_manager_secret.longhorn_backup_r2_secret_access_key
  + google_secret_manager_secret_version.longhorn_backup_r2_secret_access_key
```

## Test plan
- [ ] HCP Terraform で apply 成功
- [ ] `gcloud secrets versions access latest --secret=longhorn-backup-r2-access-key-id` で取得可
- [ ] `ExternalSecret/longhorn-backup-r2-external-secret` が `SecretSynced` (Ready=True) に遷移
- [ ] Longhorn UI で Backup Target `default` が healthy
- [ ] Longhorn の Recurring Job (`daily`, `db-6h`) が R2 にバックアップを書き込める