### PR TITLE
chore(immich-mcp): switch to upstream barryw/immichmcp:v3.2.0

### DIFF
--- a/kubernetes/applications/immich-mcp/immich-mcp.yaml
+++ b/kubernetes/applications/immich-mcp/immich-mcp.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
         - name: immich-mcp
-          image: ghcr.io/toof-jp/immichmcp:v3.1.5-base64.1
+          image: ghcr.io/barryw/immichmcp:v3.2.0
           ports:
             - name: http
               containerPort: 5000

--- a/kubernetes/applications/immich-mcp/kustomization.yaml
+++ b/kubernetes/applications/immich-mcp/kustomization.yaml
@@ -5,5 +5,3 @@ namespace: immich-mcp
 resources:
   - namespace.yaml
   - immich-mcp.yaml
-components:
-  - ../../components/ghcr-auth


### PR DESCRIPTION
## 概要

immich-mcp のイメージをフォーク版から本家 v3.2.0 に戻します。

- upstream v3.2.0 に `DOWNLOAD_MODE=base64` を実装する [barryw/ImmichMCP#19](https://github.com/barryw/ImmichMCP/pull/19) がマージ済み。これがフォーク (`ghcr.io/toof-jp/immichmcp:v3.1.5-base64.1`) を維持していた唯一の理由だったのでフォークを廃止。
- 本家イメージ `ghcr.io/barryw/immichmcp` は public のため、pull secret を注入していた `ghcr-auth` component も外す。

## 変更点

- `immich-mcp.yaml`: image を `ghcr.io/barryw/immichmcp:v3.2.0` に変更
- `kustomization.yaml`: `../../components/ghcr-auth` component を削除

## テスト

- [ ] ArgoCD で sync が通ること
- [ ] Pod が `barryw/immichmcp:v3.2.0` で起動すること (ImagePullSecret なしで pull できること)
- [ ] Claude 経由で写真のダウンロード (base64 レンダリング) が動作すること