### PR TITLE
Switch immich CNPG image to CNPG-compatible build

### DIFF
--- a/kubernetes/applications/immich/postgres-cluster.yaml
+++ b/kubernetes/applications/immich/postgres-cluster.yaml
@@ -28,7 +28,7 @@ metadata:
   namespace: immich
 spec:
   instances: 1
-  imageName: ghcr.io/immich-app/postgres:16-vectorchord0.4.3-pgvectors0.2.0
+  imageName: ghcr.io/toof-jp/postgres-vectorchord:sha-9164946
   postgresql:
     shared_preload_libraries:
       - vchord.so


### PR DESCRIPTION
## 概要

PR #224 でセットアップした immich の CNPG Cluster は `ghcr.io/immich-app/postgres` を imageName に使っていたが、この image は CNPG 非互換で bootstrap 失敗:

```
initdb: could not look up effective user ID 26: user does not exist
```

`ghcr.io/immich-app/postgres` は Debian postgres 標準の UID 999 の postgres user を持つ一方、CNPG operator は Pod securityContext を `runAsUser: 26` に固定するため、initdb が `getpwuid(26)` で fail する。

## 変更

`imageName: ghcr.io/immich-app/postgres:16-vectorchord0.4.3-pgvectors0.2.0`
→ `imageName: ghcr.io/toof-jp/postgres-vectorchord:sha-9164946`

新イメージは `toof-jp/postgres-vectorchord-image` repo で新規ビルド:
- Base: `ghcr.io/cloudnative-pg/postgresql:16-standard-trixie`
- VectorChord 0.4.3(supervc-stack/VectorChord からの prebuilt deb)
- pgvector v0.8.1(GitHub からソースビルド)

現行 immich DB の extension バージョン(`vchord 0.4.3`, `vector 0.8.1`)と一致。

## マージ後の手動リセット

失敗中の Cluster は "unrecoverable" 状態で自動リカバリしないため:

```bash
kubectl delete cluster postgres -n immich
kubectl delete pvc postgres-1 -n immich  # empty, no data — CNPG never got past initdb
```

ArgoCD が新 imageName で Cluster を再作成 → bootstrap.initdb → import が旧 StatefulSet (`postgres-0`) から実行される。

## 事後確認

- `kubectl get cluster postgres -n immich` が `Cluster in healthy state` になるまで待つ
- `SELECT count(*) FROM assets` で行数比較
- 別 PR (Phase B) で `postgres.yaml` (旧 StatefulSet) 削除 + `immich.yaml` の `DB_HOSTNAME: postgres` → `postgres-rw` にカットオーバー

🤖 Generated with [Claude Code](https://claude.com/claude-code)