### PR TITLE
Provision R2 bucket for github-repository-terraform state

### DIFF
--- a/terraform/cloudflare_r2.tf
+++ b/terraform/cloudflare_r2.tf
@@ -4,6 +4,15 @@ resource "cloudflare_r2_bucket" "longhorn_backup" {
   location   = "apac"
 }
 
+# Terraform remote state bucket for toof-jp/github-repository-terraform.
+# That repo runs Terraform outside HCP TFC (it manages GitHub repos on its
+# own) and stores its state here via the S3-compatible R2 API.
+resource "cloudflare_r2_bucket" "github_repository_terraform_state" {
+  account_id = var.cloudflare_account_id
+  name       = "toof-github-repository-terraform-state"
+  location   = "apac"
+}
+
 resource "google_secret_manager_secret" "longhorn_backup_r2_endpoints" {
   secret_id = "longhorn-backup-r2-endpoints"
   replication {


### PR DESCRIPTION
## Summary

- Adds `cloudflare_r2_bucket.github_repository_terraform_state` (`toof-github-repository-terraform-state`, apac).
- Backing bucket for the new [`toof-jp/github-repository-terraform`](https://github.com/toof-jp/github-repository-terraform) Terraform state.
- That repo declaratively manages every GitHub repo under `toof-jp` via `integrations/github`. Its state lives in R2 (not HCP TFC, not a GitHub repo) to avoid a bootstrap loop where Terraform would depend on a repo it manages.

## Follow-up (manual, outside Terraform)

After merge & HCP TFC apply:

1. Cloudflare Dashboard → R2 → API tokens → issue an Object Read & Write token scoped to `toof-github-repository-terraform-state`.
2. Store the Access Key ID / Secret Access Key wherever the github-repository-terraform repo is applied from (e.g. local `~/.envrc`, CI secret).
3. Merge https://github.com/toof-jp/github-repository-terraform/pull/1 after this PR.

## Test plan

- [ ] HCP TFC speculative plan shows only the new `cloudflare_r2_bucket` resource being created
- [ ] After apply, `toof-github-repository-terraform-state` bucket is visible in the Cloudflare R2 console
- [ ] Bucket location is `apac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)