### PR TITLE
Use CNPG-valid version-prefixed image tags for bbs and immich

### DIFF
--- a/kubernetes/applications/bbs/postgres-cluster.yaml
+++ b/kubernetes/applications/bbs/postgres-cluster.yaml
@@ -28,7 +28,7 @@ metadata:
   namespace: bbs
 spec:
   instances: 1
-  imageName: ghcr.io/toof-jp/postgres-bigm:sha-4c22b29
+  imageName: ghcr.io/toof-jp/postgres-bigm:18-4c22b29
   postgresql:
     shared_preload_libraries:
       - pg_bigm

--- a/kubernetes/applications/immich/postgres-cluster.yaml
+++ b/kubernetes/applications/immich/postgres-cluster.yaml
@@ -28,7 +28,7 @@ metadata:
   namespace: immich
 spec:
   instances: 1
-  imageName: ghcr.io/toof-jp/postgres-vectorchord:sha-9164946
+  imageName: ghcr.io/toof-jp/postgres-vectorchord:16-9164946
   postgresql:
     shared_preload_libraries:
       - vchord.so


### PR DESCRIPTION
## 概要

infra #228 (bbs) と #233 (immich) 両方がマージ後 ArgoCD で sync 失敗:

```
admission webhook "vcluster.cnpg.io" denied the request: Cluster.postgresql.cnpg.io "postgres" is invalid:
spec.imageName: Invalid value: "ghcr.io/toof-jp/postgres-bigm:sha-4c22b29": invalid version tag
spec.imageName: Invalid value: "ghcr.io/toof-jp/postgres-vectorchord:sha-9164946": invalid version tag
```

CNPG の admission webhook は `imageName` の tag を `^(\d+)(\.(\d+))?` の正規表現で PostgreSQL major version として抽出する。`sha-XXX` は数字始まりでないため fail。

## 対応

既存 GHCR manifest に crane で version-prefixed tag を追加(再ビルド不要、同一 manifest への alias):

```
crane tag ghcr.io/toof-jp/postgres-bigm:sha-4c22b29 18-4c22b29
crane tag ghcr.io/toof-jp/postgres-vectorchord:sha-9164946 16-9164946
```

Cluster spec の `imageName` を新 tag に差し替え:

- `postgres-bigm:sha-4c22b29` → `postgres-bigm:18-4c22b29`
- `postgres-vectorchord:sha-9164946` → `postgres-vectorchord:16-9164946`

## フォローアップ

- `toof-jp/postgres-bigm-docker` の CI (`type=sha` → `type=sha,prefix=18-`) 変更
- `toof-jp/postgres-vectorchord-image` の CI (`type=sha` → `type=sha,prefix=16-`) 変更
- 変更後 Renovate が cnpg-friendly tag を追跡できるようになる

## マージ後

- ArgoCD sync 成功で bbs / immich の CNPG Cluster が起動、旧 StatefulSet から microservice import 開始

🤖 Generated with [Claude Code](https://claude.com/claude-code)