### PR TITLE
fix(terraform): drop stale oci_vps_2 import block

### DIFF
--- a/terraform/oci.tf
+++ b/terraform/oci.tf
@@ -173,14 +173,6 @@ output "oci_vps_private_ip" {
   value = oci_core_instance.oci_vps.private_ip
 }
 
-# oci-vps-2: second always-free E2.1.Micro, added 2026-07-21 to replace
-# the terminated instance-20260120-2338 slot and stand up another k8s
-# worker. Launched via the OCI CLI on 2026-07-21 and adopted here.
-import {
-  to = oci_core_instance.oci_vps_2
-  id = "ocid1.instance.oc1.ap-osaka-1.anvwsljrlfc45kicwmfirh5c7tnkunhauqyrjvm4zakjcmvf6ek6xlmjd3eq"
-}
-
 resource "oci_core_instance" "oci_vps_2" {
   compartment_id      = var.oci_tenancy_ocid
   availability_domain = "yPbU:AP-OSAKA-1-AD-1"


### PR DESCRIPTION
## 概要
`oci_core_instance.oci_vps_2` の import block を削除して workspace の plan を復旧させる。resource block は残すので、次回 apply で新規に oci-vps-2 が作成される。

## 背景
コミット \`e70e178 Add second always-free OCI E2.1.Micro (oci-vps-2) as k8s worker\` で追加された:
\`\`\`hcl
import {
  to = oci_core_instance.oci_vps_2
  id = "ocid1.instance.oc1.ap-osaka-1.anvwsljrlfc45kicwmfirh5c7tnkunhauqyrjvm4zakjcmvf6ek6xlmjd3eq"
}
\`\`\`
の指す OCI インスタンスが実在せず、HCP Terraform の全 plan が
\`\`\`
Error: Cannot import non-existent remote object
\`\`\`
で落ちる。**workspace 全体が blocked** で他 PR (#230 など) も plan が通らない状態。

## 状況
- \`kubectl get nodes\` に \`oci-vps-2\` は unattached、\`oci-vps\` (v1) のみ稼働
- Always Free E2.1.Micro を ap-osaka-1 に立てて import したがその後 reclaim されたと推測

## 対処案の比較
| 案 | 挙動 | 選択理由 |
|---|---|---|
| import block を修正 | 実在するインスタンスの OCID を差し替え | 実物が無いので不可 |
| resource ごと削除 | oci-vps-2 を諦める | ノード追加意図と反するので却下 |
| **import block だけ削除**(本 PR) | apply 時に新規作成させる | \`prevent_destroy=true\` は create を阻害しない。Always Free 枠なら再取得可能 |

## Plan 結果
\`\`\`
Plan: 2 to add, 2 to change, 0 to destroy.
  + oci_core_instance.oci_vps_2  ← 本 PR の意図した変更
  + cloudflare_r2_bucket.github_repository_terraform_state  ← 既存のペンディング差分
  ~ auth0_client.mcp["beancount-mcp"]  ← 既存の drift
  ~ auth0_client.mcp["dawarich-mcp"]   ← 既存の drift
\`\`\`
apply 時に上記 add/change が同時に反映されるので注意。

## Test plan
- [ ] HCP Terraform で plan が通る(この PR の check pass)
- [ ] apply 後 \`oci compute instance list\` で新 oci-vps-2 が Running
- [ ] nixos-infect + tailscale を再度流して k8s ノードとして参加
- [ ] apply 完了で workspace 詰まりが解消し、#230 の plan が自動再走