### PR TITLE
Auto-provision R2 API token for github-repository-terraform state

### DIFF
--- a/terraform/cloudflare_r2.tf
+++ b/terraform/cloudflare_r2.tf
@@ -65,3 +65,43 @@ resource "google_secret_manager_secret_version" "longhorn_backup_r2_secret_acces
   secret      = google_secret_manager_secret.longhorn_backup_r2_secret_access_key.id
   secret_data = sha256(cloudflare_api_token.longhorn_backup_r2.value)
 }
+
+resource "cloudflare_api_token" "github_repository_terraform_state" {
+  name = "github-repository-terraform-state"
+  policies = [{
+    effect = "allow"
+    resources = jsonencode({
+      "com.cloudflare.edge.r2.bucket.${var.cloudflare_account_id}_default_${cloudflare_r2_bucket.github_repository_terraform_state.name}" = "*"
+    })
+    permission_groups = [
+      { id = "6a018a9f2fc74eb6b293b0c548f38b39" }, # Workers R2 Storage Bucket Item Read
+      { id = "2efd5506f9c8494dacb1fa10a3e7d5b6" }, # Workers R2 Storage Bucket Item Write
+    ]
+  }]
+}
+
+resource "google_secret_manager_secret" "github_repository_terraform_state_r2_access_key_id" {
+  secret_id = "github-repository-terraform-state-r2-access-key-id"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "github_repository_terraform_state_r2_access_key_id" {
+  secret      = google_secret_manager_secret.github_repository_terraform_state_r2_access_key_id.id
+  secret_data = cloudflare_api_token.github_repository_terraform_state.id
+}
+
+resource "google_secret_manager_secret" "github_repository_terraform_state_r2_secret_access_key" {
+  secret_id = "github-repository-terraform-state-r2-secret-access-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "github_repository_terraform_state_r2_secret_access_key" {
+  secret      = google_secret_manager_secret.github_repository_terraform_state_r2_secret_access_key.id
+  secret_data = sha256(cloudflare_api_token.github_repository_terraform_state.value)
+}


### PR DESCRIPTION
## Summary

- Follow-up to #234: now that the `toof-github-repository-terraform-state` R2 bucket exists, provision an S3-compatible API token for it automatically.
- Adds `cloudflare_api_token.github_repository_terraform_state` scoped to just that bucket (Object Read + Write).
- Stashes the derived credentials in Google Secret Manager:
  - `github-repository-terraform-state-r2-access-key-id` = token `id`
  - `github-repository-terraform-state-r2-secret-access-key` = `sha256(token.value)`
- Mirrors the existing `longhorn_backup_r2` block above verbatim (permission group IDs, resource string format, secret naming pattern).

## Why

Without this, someone still has to click through the Cloudflare dashboard to issue R2 access keys before `github-repository-terraform` can `terraform init`. With this, they run `gcloud secrets versions access latest --secret=...` instead — same pattern longhorn already uses.

## Test plan

- [ ] HCP TFC plan shows only new resources (1 `cloudflare_api_token` + 2 `google_secret_manager_secret` + 2 `google_secret_manager_secret_version`); no drift on the existing `longhorn_backup_r2` block
- [ ] After apply, `gcloud secrets versions access latest --secret=github-repository-terraform-state-r2-access-key-id --project=toof-infra` returns a non-empty string
- [ ] Same for `-secret-access-key`
- [ ] Using those two as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, `terraform init -backend-config=backend.hcl` succeeds in toof-jp/github-repository-terraform

🤖 Generated with [Claude Code](https://claude.com/claude-code)