### PR TITLE
Bump immich CNPG image to pgvector-portable build

### DIFF
--- a/kubernetes/applications/immich/postgres-cluster.yaml
+++ b/kubernetes/applications/immich/postgres-cluster.yaml
@@ -28,7 +28,7 @@ metadata:
   namespace: immich
 spec:
   instances: 1
-  imageName: ghcr.io/toof-jp/postgres-vectorchord:16-9164946
+  imageName: ghcr.io/toof-jp/postgres-vectorchord:16-04ed4a4
   postgresql:
     shared_preload_libraries:
       - vchord.so


### PR DESCRIPTION
## 概要

前回の `16-9164946` は pgvector を `-march=native` で GitHub Actions runner 上でビルドしていたため zen2 で `CREATE EXTENSION vector` が SIGILL crash した。

`postgres-vectorchord-image#1` で pgvector build に `OPTFLAGS='-march=x86-64-v3 -ftree-vectorize'` を指定 + CI meta tag を `type=sha,prefix=16-` に。新 image `sha-16-04ed4a4` publish 済み。

## 変更

`imageName: ghcr.io/toof-jp/postgres-vectorchord:16-9164946` → `:16-04ed4a4`

## マージ後の手動リセット

失敗中 Cluster は unrecoverable 状態のまま(前回と同じ):

```bash
kubectl delete cluster postgres -n immich
kubectl delete pvc postgres-1 -n immich  # empty, initdb never completed
```

ArgoCD が新 image で Cluster 再作成 → bootstrap → import が旧 postgres-0 から実行される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)