### PR TITLE
fix(mirakc): mount config.yml via subPath

### DIFF
--- a/kubernetes/applications/mirakc/mirakc.yaml
+++ b/kubernetes/applications/mirakc/mirakc.yaml
@@ -82,7 +82,8 @@ spec:
             allowPrivilegeEscalation: false
           volumeMounts:
             - name: config
-              mountPath: /etc/mirakc
+              mountPath: /etc/mirakc/config.yml
+              subPath: config.yml
               readOnly: true
             - name: epg
               mountPath: /var/lib/mirakc/epg


### PR DESCRIPTION
## Summary

mirakc Pod が CrashLoopBackOff で起動しない問題の修正。

```
thread 'main' (1) panicked at mirakc-core/src/config.rs:1240:9:
config.resource.strings-yaml: must be a path to an existing YAML file
```

## 原因

`/etc/mirakc` にConfigMapをディレクトリ丸ごとマウントしていたため、base image (`mirakc/mirakc:3.4.77-debian`) に含まれる `/etc/mirakc/strings.yml` がマウントで隠され、mirakcの起動時チェックで exit していた。

## 修正

`config.yml` だけを subPath マウントに変更。base image の他ファイル（`strings.yml` 等）は残るので mirakc は起動できる。

## Test plan

- [x] `kubectl kustomize` 通過
- [ ] マージ後 mirakc Pod が Running になること
- [ ] `/api/version` `/api/channels` に応答すること