### PR TITLE
fix(mirakc): EPGStation volume conflict + mirakc DVB device access

### DIFF
--- a/kubernetes/applications/mirakc/epgstation.yaml
+++ b/kubernetes/applications/mirakc/epgstation.yaml
@@ -99,10 +99,8 @@ spec:
               mountPath: /app/recorded
             - name: thumbnail
               mountPath: /app/thumbnail
-              subPath: thumbnail
             - name: drop
               mountPath: /app/drop
-              subPath: drop
       volumes:
         - name: config
           configMap:
@@ -113,15 +111,13 @@ spec:
         - name: recorded
           persistentVolumeClaim:
             claimName: epgstation-recorded
-        # thumbnails and drop logs live alongside the DB — small and
-        # cheap; a subPath on the same PVC keeps everything in one
-        # snapshot boundary.
+        # Thumbnails and drop logs are regenerable / ephemeral. Keeping
+        # them off the DB PVC avoids Longhorn's one-attachment-per-RWO
+        # constraint when the same PVC is referenced multiple times.
         - name: thumbnail
-          persistentVolumeClaim:
-            claimName: epgstation-data
+          emptyDir: {}
         - name: drop
-          persistentVolumeClaim:
-            claimName: epgstation-data
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/applications/mirakc/mirakc.yaml
+++ b/kubernetes/applications/mirakc/mirakc.yaml
@@ -76,10 +76,13 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
           securityContext:
-            # DVB device access needs read/write, not privileged.
-            capabilities:
-              drop: ["ALL"]
-            allowPrivilegeEscalation: false
+            # DVB frontend ioctls are blocked by the default device
+            # cgroup even for root+video-group, so recisdb sees EPERM
+            # opening /dev/dvb/adapterN/frontend0. Kubernetes has no
+            # per-device allowlist outside a full device plugin, so
+            # this is the pragmatic escape hatch for a single-node
+            # home tuner setup.
+            privileged: true
           volumeMounts:
             - name: config
               mountPath: /etc/mirakc/config.yml


### PR DESCRIPTION
## Summary

デプロイ後の実機検証で見つかった2件の不具合を修正するPR。

### 1. EPGStation Pod が ContainerCreating で止まる

kubelet ログ:
```
err="unmounted volumes=[data thumbnail], unattached volumes=[],
failed to process volumes=[data thumbnail]: context deadline exceeded"
```

**原因**: 同じ `epgstation-data` PVC を `data` / `thumbnail` / `drop` の3つの独立volume entry として参照。Longhorn RWO は1 Pod につき1アタッチのみ。

**修正**: `thumbnail` と `drop` を `emptyDir` に変更（Thumbnail は EPGStation が再生成、drop log は運用上失っても可）。

### 2. mirakc が recisdb tune で EPERM

mirakc 起動後、EPG収集ジョブが全チャンネル `err=No clock, maybe out of service` で失敗。原因を追跡するとコンテナ内で:
```
$ recisdb tune --device /dev/dvb/adapter0/frontend0 --channel T15 --time 3 /tmp/t.m2ts
ERROR    Operation not permitted while opening /dev/dvb/adapter0/frontend0
```

コンテナは UID=0 + `supplementalGroups: [26]` で `/dev/dvb/adapter0/frontend0` (`crw-rw---- root:tape`) にファイル的にはアクセスできるが、**k8s のデフォルト device cgroup がキャラクタデバイス ioctl をブロック**する。

**修正**: `securityContext.privileged: true`。素の kubeadm では他に軽い選択肢がない（KEP-3459 `securityContext.devices` は k8s 1.31+ で使えるが今回は 1.34 なので将来的な移行検討可）。家庭内シングルノード用途では特権化が実務解。

## Test plan

- [x] `bun run format:check` / `kubeconform -strict`（11 Valid）
- [ ] マージ後 EPGStation Pod Running 到達
- [ ] mirakc `/api/channels` で 7チャンネル応答
- [ ] EPG 収集ジョブが `Saved schedules schedules.len>0` を吐くこと
- [ ] Web UI (`epgstation.toof.jp`) 番組表表示