### PR TITLE
fix(epgstation): materialize default log/enc configs in the image

### DIFF
--- a/docker/epgstation/Dockerfile
+++ b/docker/epgstation/Dockerfile
@@ -10,3 +10,11 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ffmpeg \
     && rm -rf /var/lib/apt/lists/*
+
+# The base image ships log config as *.sample.yml and enc.js as
+# *.template, but EPGStation looks up the un-suffixed names at boot
+# and exits with "log file is not found" if they're missing. Convert
+# them once here so the container works with only config.yml mounted.
+RUN set -eux; cd /app/config; \
+    for f in *.sample.yml; do cp -n "$f" "${f%.sample.yml}.yml"; done; \
+    for f in *.template; do cp -n "$f" "${f%.template}"; done


### PR DESCRIPTION
## Summary

EPGStation Pod が起動直後に \`log file is not found\` で終了する問題の修正。

## 原因

l3tnun/epgstation の base image は log 設定を \`*.sample.yml\`、encoder スクリプトを \`*.template\` の形で同梱している。運用者がリネームして使う想定だが、ConfigMap で \`config.yml\` だけ用意した現構成では他ファイルが揃わず起動失敗する。

## 修正

Dockerfile の build 時に \`*.sample.yml → *.yml\` と \`*.template → *\`（無サフィックス）へリネームコピーする。ConfigMap で明示的に上書きする分は subPath マウントで拾えるので、後から差し替えられる。

## Test plan

- [ ] GHA build 成功 → \`ghcr.io/toof-jp/infra-epgstation:latest\` 更新
- [ ] マージ後 EPGStation Pod Running 到達
- [ ] Web UI (\`epgstation.toof.jp\`) 到達