### PR TITLE
fix(mirakc): bump image digests to include log-config fix

### DIFF
--- a/kubernetes/applications/mirakc/epgstation.yaml
+++ b/kubernetes/applications/mirakc/epgstation.yaml
@@ -61,7 +61,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: epgstation
-          image: ghcr.io/toof-jp/infra-epgstation:latest@sha256:471e22d398abc3eb9abf1dcf93520dbf8660e004717ea3a322b4d10a4f7a5531
+          image: ghcr.io/toof-jp/infra-epgstation:sha-ebd2976@sha256:a21757a061bf159f2c5e979cc842e5c05eb24bb1c24ded52a37e3913639d72ad
           imagePullPolicy: Always
           env:
             - name: TZ

--- a/kubernetes/applications/mirakc/mirakc.yaml
+++ b/kubernetes/applications/mirakc/mirakc.yaml
@@ -46,7 +46,7 @@ spec:
         supplementalGroups: [26]
       containers:
         - name: mirakc
-          image: ghcr.io/toof-jp/infra-mirakc:latest@sha256:ced73ad64c67b2f9709d526e5a4dfc52674d837a041f19837e93c8972a5583eb
+          image: ghcr.io/toof-jp/infra-mirakc:sha-ebd2976@sha256:1dc827aadd93840b835e100af78423eeb324dcd1ecdec86741dbad5c2a03af8f
           imagePullPolicy: Always
           env:
             - name: TZ


### PR DESCRIPTION
## Summary

manifest の image が Renovate によって \`sha256:471e22...\` / \`sha256:ced73ad...\` (PR #242 の初回build) に pin されており、PR #248 で追加した log 設定 fix を含む新しい digest がまだ反映されていない。次のRenovate巡回を待たずに直接 \`sha-ebd2976\` に更新。

## 変更

- \`infra-mirakc\`: → \`sha256:1dc827aa...\`
- \`infra-epgstation\`: → \`sha256:a21757a0...\`

どちらも tag \`sha-ebd2976\` に対応。

## Test plan

- [ ] マージ後 EPGStation Pod Running 到達
- [ ] Web UI (\`epgstation.toof.jp\`) 応答