### PR TITLE
fix(epgstation): stdout-only log configs via ConfigMap

### DIFF
--- a/kubernetes/applications/mirakc/epgstation-config.yaml
+++ b/kubernetes/applications/mirakc/epgstation-config.yaml
@@ -35,3 +35,62 @@ data:
 
     isSuppressReservesUpdateAllLog: true
     isAllowedSameNameRecording: true
+
+  # log4js configs. The bundled *.sample.yml references %OperatorSystem%
+  # style filename tokens that EPGStation only substitutes when the
+  # corresponding *Log paths are set in config.yml; without them log4js
+  # blows up validating the filename regex. Ship a minimal stdout-only
+  # config so kubectl logs picks up everything.
+  operatorLogConfig.yml: |
+    appenders:
+      stdout:
+        type: stdout
+    categories:
+      default:
+        appenders: [stdout]
+        level: info
+      system:
+        appenders: [stdout]
+        level: info
+      access:
+        appenders: [stdout]
+        level: info
+      stream:
+        appenders: [stdout]
+        level: info
+
+  epgUpdaterLogConfig.yml: |
+    appenders:
+      stdout:
+        type: stdout
+    categories:
+      default:
+        appenders: [stdout]
+        level: info
+      system:
+        appenders: [stdout]
+        level: info
+      access:
+        appenders: [stdout]
+        level: info
+      stream:
+        appenders: [stdout]
+        level: info
+
+  serviceLogConfig.yml: |
+    appenders:
+      stdout:
+        type: stdout
+    categories:
+      default:
+        appenders: [stdout]
+        level: info
+      system:
+        appenders: [stdout]
+        level: info
+      access:
+        appenders: [stdout]
+        level: info
+      stream:
+        appenders: [stdout]
+        level: info

--- a/kubernetes/applications/mirakc/epgstation.yaml
+++ b/kubernetes/applications/mirakc/epgstation.yaml
@@ -93,6 +93,18 @@ spec:
               mountPath: /app/config/config.yml
               subPath: config.yml
               readOnly: true
+            - name: config
+              mountPath: /app/config/operatorLogConfig.yml
+              subPath: operatorLogConfig.yml
+              readOnly: true
+            - name: config
+              mountPath: /app/config/epgUpdaterLogConfig.yml
+              subPath: epgUpdaterLogConfig.yml
+              readOnly: true
+            - name: config
+              mountPath: /app/config/serviceLogConfig.yml
+              subPath: serviceLogConfig.yml
+              readOnly: true
             - name: data
               mountPath: /app/data
             - name: recorded


### PR DESCRIPTION
## Summary

前PR (#248) で Dockerfile 内で \`*.sample.yml → *.yml\` にリネームしたが、その中身が \`filename: \"%OperatorSystem%\"\` のようなプレースホルダを含んでおり、EPGStation が \`log file parse error\` で落ちる。

## 修正

log4js の設定を stdout のみに絞ったものを ConfigMap に3ファイル追加し、subPath マウントで上書き。これで:

- Pod のログは kubectl logs で全部見える
- ローテーション不要（k8sログ回転で管理）
- \`%OperatorSystem%\` 系トークン依存が消える

## Test plan

- [x] \`bun run format:check\` / \`kubeconform -strict\`（11 Valid）
- [ ] マージ後 EPGStation Pod Running 到達
- [ ] Web UI (\`epgstation.toof.jp\`) 応答