### PR TITLE
Unpin nemousu-redirector from sakura-vps

### DIFF
--- a/kubernetes/applications/bbs/nemousu-redirector.yaml
+++ b/kubernetes/applications/bbs/nemousu-redirector.yaml
@@ -16,11 +16,6 @@ spec:
       labels:
         app: nemousu-redirector
     spec:
-      # Pinned to sakura-vps because the public DNS A record for
-      # nemousu.live-on.net points at this node's fixed IP
-      # (153.126.161.157) and traffic is served via NodePort on that node.
-      nodeSelector:
-        kubernetes.io/hostname: sakura-vps
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists


### PR DESCRIPTION
## 背景

昨夜 (2026-07-21 22:47 JST) sakura-vps がメモリ枯渇で kubelet ハートビート停止 → NotReady → tailscale から応答不能となり、コンパネからの強制再起動で復旧した ([[immich-recovery-2026-07]] と同系統のインシデント)。

現状 sakura-vps は 3.8 GiB VPS に control-plane (kube-apiserver 780 MiB / etcd 111 MiB) + longhorn-manager + instance-manager を載せていて余裕がない。

## 変更内容

nemousu-redirector Deployment の `nodeSelector: kubernetes.io/hostname: sakura-vps` を削除し、任意ノードでスケジュール可能にする。

- Service は `type: NodePort` で `externalTrafficPolicy` 未指定 (= 既定の `Cluster`) なので、sakura の NodePort に届いたトラフィックは kube-proxy が pod のいるノードに SNAT 転送する。pod がどこにいても通信は成立する。
- 公開 DNS が sakura の IP を指しているため、sakura ダウン時のユーザー体験は変わらない (可用性ではなく sakura のメモリ節約が目的)。
- control-plane toleration は残しているので、他ノードに余裕がなければ引き続き sakura に戻ってこられる。

## Test plan

- [ ] マージ後 pod が Ready で走ることを確認
- [ ] `curl` で `nemousu.live-on.net` (sakura の NodePort) が引き続きリダイレクトを返すことを確認