### PR TITLE
Unmanage oci_vps_2 from terraform state (stale OCID)

### DIFF
--- a/terraform/oci.tf
+++ b/terraform/oci.tf
@@ -173,37 +173,19 @@ output "oci_vps_private_ip" {
   value = oci_core_instance.oci_vps.private_ip
 }
 
-resource "oci_core_instance" "oci_vps_2" {
-  compartment_id      = var.oci_tenancy_ocid
-  availability_domain = "yPbU:AP-OSAKA-1-AD-1"
-  shape               = "VM.Standard.E2.1.Micro"
-  display_name        = "oci-vps-2"
-
-  source_details {
-    source_type             = "image"
-    source_id               = "ocid1.image.oc1.ap-osaka-1.aaaaaaaakkk2ftbt2ztpw3jdriwhadh4xi4rbdi4fspi2xcv27cx7xqj45pq"
-    boot_volume_size_in_gbs = 100
-  }
-
-  create_vnic_details {
-    subnet_id        = oci_core_subnet.k8s.id
-    assign_public_ip = true
-    hostname_label   = "oci-vps-2"
-  }
-
-  metadata = {
-    ssh_authorized_keys = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIN8H2c3Qa2EsEh6RQG6nRoRFblH8fj5dHj9YyVD9tND toof@toof.jp"
-  }
-
+# oci-vps-2 is unmanaged by terraform for now. PR #215 imported it
+# against OCID ...wmfirh5c...jd3eq, but that instance was terminated
+# after a boot-failure debug loop; the current live oci-vps-2 was
+# rebuilt via manual LUSTRATE on a fresh boot volume with a different
+# OCID (...4gn5e5vbwi...zideaq7dlqhtbta). Rather than juggle state
+# mismatches, unmanage the resource here. A follow-up PR can re-import
+# it with the current OCID once the k8s worker is proven stable.
+#
+# `lifecycle { destroy = false }` on the removed block preserves the
+# actual instance — terraform only drops it from state.
+removed {
+  from = oci_core_instance.oci_vps_2
   lifecycle {
-    prevent_destroy = true
+    destroy = false
   }
-}
-
-output "oci_vps_2_public_ip" {
-  value = oci_core_instance.oci_vps_2.public_ip
-}
-
-output "oci_vps_2_private_ip" {
-  value = oci_core_instance.oci_vps_2.private_ip
 }


### PR DESCRIPTION
## 概要

PR #215 で import した oci_vps_2 の OCID (\`...wmfirh5c...jd3eq\`) は既に消えていて (7時間の nixos-infect 迷走の過程で terminate)、現在稼働中の oci-vps-2 は別の OCID (\`...4gn5e5vbwi...zideaq7dlqhtbta\`) です。terraform state と実体の OCID が食い違ったまま HCP に auto-apply されると、\`prevent_destroy\` にぶつかるか、あるいは新しい Ubuntu instance を作りに行って動いてる NixOS worker を無視する形になるため、いったん \`removed { lifecycle { destroy = false } }\` で **state からだけ外し**、実インスタンスは触らない対応。

## 現況

- oci-vps-2 (public 150.230.4.75 / tailnet 100.83.7.89) は NixOS 26.05 で kubeadm join 済み worker、kubelet active
- nix-sandbox 側の host config は toof-jp/nix-sandbox#5 参照

## Follow-up

worker として一週間ほど安定稼働を確認したら、別 PR で新 OCID の import block + 元の resource / output を restore します。