### PR TITLE
fix(longhorn): point recurring jobs at the default group

### DIFF
--- a/kubernetes/applications/longhorn-system/recurring-jobs.yaml
+++ b/kubernetes/applications/longhorn-system/recurring-jobs.yaml
@@ -8,7 +8,7 @@ spec:
   cron: "0 */6 * * *"
   task: backup
   groups:
-    - db-6h
+    - default
   retain: 4
   concurrency: 2
 ---
@@ -21,6 +21,6 @@ spec:
   cron: "0 18 * * *"
   task: backup
   groups:
-    - daily
+    - default
   retain: 7
   concurrency: 2


### PR DESCRIPTION
## 概要

Longhorn の R2 バックアップが実際は一度も走っていなかったのを修正。

## 状況

- BackupTarget (\`s3://toof-longhorn-backup@us-east-1/\`) は \`available: true\` で R2 と接続できていた
- しかし \`Backup\` / \`BackupVolume\` CR が 0 件、全 22 volume の \`status.lastBackup\` が空

## 原因

Longhorn は volume 作成時に \`recurring-job-group.longhorn.io/default=enabled\` のラベルを自動付与する。一方、\`recurring-jobs.yaml\` の RecurringJob は \`groups: [db-6h]\` / \`groups: [daily]\` を対象にしており、\`default\` グループの volume を拾えていなかった。結果、cron は発火しても対象 volume が 0 でバックアップが作成されない状態。

## 変更内容

- \`db-6h\` / \`daily\` の \`groups\` を \`default\` に変更（cron・retain・concurrency は据え置き）

これにより全 volume が対象になり、6時間ごとに直近4世代 + 毎日18:00に直近7世代がR2に保存される。

## 動作確認 TODO

- [ ] Argo CD 同期後、\`kubectl -n longhorn-system get recurringjob\` の groups が \`[default]\` に変わっていること
- [ ] 次の cron 発火後に \`kubectl -n longhorn-system get backup\` にレコードが出ること
- [ ] R2 バケット \`toof-longhorn-backup\` の使用量が増えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)