### PR TITLE
chore(bbs): wait for postgres before DB consumers start

### DIFF
--- a/kubernetes/applications/bbs/discord-webhook.yaml
+++ b/kubernetes/applications/bbs/discord-webhook.yaml
@@ -13,6 +13,13 @@ spec:
       labels:
         app: discord-webhook
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:18-alpine
+          command:
+            - sh
+            - -c
+            - until pg_isready -h postgres-rw -p 5432; do sleep 2; done
       containers:
         - name: discord-webhook
           image: ghcr.io/toof-jp/discord-webhook:sha-4319bdc

--- a/kubernetes/applications/bbs/fetch-post-discord-bot.yaml
+++ b/kubernetes/applications/bbs/fetch-post-discord-bot.yaml
@@ -13,6 +13,13 @@ spec:
       labels:
         app: fetch-post-discord-bot
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:18-alpine
+          command:
+            - sh
+            - -c
+            - until pg_isready -h postgres-rw -p 5432; do sleep 2; done
       containers:
         - name: fetch-post-discord-bot
           image: ghcr.io/toof-jp/bbs-fetch-post-discord-bot:sha-8f9fd09

--- a/kubernetes/applications/bbs/search-backend.yaml
+++ b/kubernetes/applications/bbs/search-backend.yaml
@@ -13,6 +13,13 @@ spec:
       labels:
         app: search-backend
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:18-alpine
+          command:
+            - sh
+            - -c
+            - until pg_isready -h postgres-rw -p 5432; do sleep 2; done
       containers:
         - name: search-backend
           image: ghcr.io/toof-jp/bbs-search-backend:sha-a6eebce

--- a/kubernetes/applications/bbs/search-crawler.yaml
+++ b/kubernetes/applications/bbs/search-crawler.yaml
@@ -13,6 +13,13 @@ spec:
       labels:
         app: search-crawler
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:18-alpine
+          command:
+            - sh
+            - -c
+            - until pg_isready -h postgres-rw -p 5432; do sleep 2; done
       containers:
         - name: search-crawler
           image: ghcr.io/toof-jp/search-crawler:sha-217bd64


### PR DESCRIPTION
## 概要

`kubernetes/applications/bbs/` の依存関係を調査し、Postgres (`postgres-rw:5432`) が起動していないと動作できない 4 つの Deployment に `pg_isready` を用いた initContainer を追加しました。CNPG クラスタが接続を受け付けるまで、これらのアプリの本体コンテナは起動しません。

## 対象ワークロード

DB へ直接接続する 4 つ (いずれも `postgres-secret` / `DATABASE_URL` を利用):

- `search-backend`
- `search-crawler`
- `fetch-post-discord-bot`
- `discord-webhook`

以下は Postgres に直接依存しないため変更なし:

- `mcp-server` / `search-post-discord-bot` — `search-backend` に HTTP でアクセス
- `nemousu-redirector` — Caddy リダイレクタ
- `mydns-jp-updater` — mydns.jp を更新する CronJob

## 追加した initContainer

```yaml
initContainers:
  - name: wait-for-postgres
    image: postgres:18-alpine
    command:
      - sh
      - -c
      - until pg_isready -h postgres-rw -p 5432; do sleep 2; done
```

- CNPG が公開する `postgres-rw` Service (同一 namespace `bbs`) を対象。
- ポートオープンだけを見る `nc` ではなく、Postgres が接続受け入れ可能になったかを判定する `pg_isready` を使用。
- `pg_isready` は認証を行わないため、認証情報の受け渡しは不要。

## 動作確認

- `npx prettier --check kubernetes/applications/bbs/*.yaml` → OK
- `kubectl apply --dry-run=client -f <対象4ファイル>` → すべて `configured (dry run)`
- `git diff --staged | opencode run` によるレビュー実施済み (指摘は認証・タグ・タイムアウトの 3 点だったが、いずれも本変更の意図の範囲内と判断)