### PR TITLE
chore(longhorn): default replica count to 2

### DIFF
--- a/kubernetes/applications/longhorn-system/kustomization.yaml
+++ b/kubernetes/applications/longhorn-system/kustomization.yaml
@@ -18,10 +18,10 @@ helmCharts:
         jobEnabled: false
       defaultSettings:
         taintToleration: node-role.kubernetes.io/control-plane=:NoSchedule
-        defaultReplicaCount: 1
+        defaultReplicaCount: 2
         concurrentAutomaticEngineUpgradePerNodeLimit: 1
       persistence:
-        defaultClassReplicaCount: 1
+        defaultClassReplicaCount: 2
       longhornManager:
         tolerations: &controlPlaneToleration
           - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## 概要

Longhorn の `defaultReplicaCount` と `defaultClassReplicaCount` を 1 → 2 に変更。

## 背景

2026-07-23 の nuc メンテナンス（NotReady 化）時、単一 replica でしか作られていなかった以下のボリュームが一斉に `detached / faulted` に落ちてワークロード停止。

- `bbs/postgres-1`
- `immich/postgres-1`
- `dawarich/postgres-1`
- `mirakc/epgstation-recorded`
- `mirakc/mirakc-epg`
- `mirakc/epgstation-data`

いずれも `numberOfReplicas=1` かつバックアップ未設定で、replica が置かれていた nuc のダウン即データ利用不可となる構成だった。

## 効果と限界

- 以降 **新規に作成される** ボリュームは 2 replica で作られ、単一ノード障害では faulted しなくなる。
- 既存ボリュームは spec を継承したまま変わらないので、必要に応じて `kubectl -n longhorn-system patch volume/<name> --type=merge -p '{"spec":{"numberOfReplicas":2}}'` で個別に引き上げる。
- 実効ストレージ消費は倍になるため、各ノードの空き容量を要確認。
- Longhorn は既定で replica を別ノードに配置（soft anti-affinity=false）するため 2 ノード以上の稼働が前提。

## Test plan

- [ ] ArgoCD で Longhorn Application が Sync 後、`kubectl -n longhorn-system get settings.longhorn.io default-replica-count` が `{"v1":"2","v2":"2"}` になっている
- [ ] `kubectl get storageclass longhorn -o yaml` の `numberOfReplicas` パラメータが `"2"` になっている
- [ ] 新規 PVC を作って replica が 2 ノードに分散していることを確認