### PR TITLE
refactor(obsidian-msp): hot-swap mcpvault on git-sync worktree rotation

### DIFF
--- a/kubernetes/applications/obsidian-msp/obsidian-msp.yaml
+++ b/kubernetes/applications/obsidian-msp/obsidian-msp.yaml
@@ -50,8 +50,25 @@ spec:
               until [ -e /git/vault ]; do
                 sleep 1
               done
-              readlink -f /git/vault > /tmp/vault-path
-              exec npx --yes mcp-proxy@6.5.2 --port 3001 -- npx --yes @bitbonsai/mcpvault@0.11.0 /git/vault
+              start() {
+                npx --yes mcp-proxy@6.5.2 --port 3001 -- npx --yes @bitbonsai/mcpvault@0.11.0 /git/vault &
+                PID=$!
+              }
+              trap 'kill $PID 2>/dev/null; wait $PID 2>/dev/null; exit 0' TERM INT
+              current=$(readlink -f /git/vault)
+              start
+              while sleep 10; do
+                if ! kill -0 $PID 2>/dev/null; then
+                  exit 1
+                fi
+                new=$(readlink -f /git/vault)
+                if [ "$new" != "$current" ]; then
+                  kill $PID 2>/dev/null || true
+                  wait $PID 2>/dev/null || true
+                  current=$new
+                  start
+                fi
+              done
           ports:
             - name: http-mcp
               containerPort: 3001
@@ -61,11 +78,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - '[ ! -f /tmp/vault-path ] || [ "$(readlink -f /git/vault)" = "$(cat /tmp/vault-path)" ]'
+            tcpSocket:
+              port: http-mcp
             initialDelaySeconds: 30
             periodSeconds: 30
           volumeMounts:


### PR DESCRIPTION
## 概要

`obsidian-msp` deployment の `mcpvault` コンテナが、git-sync による `/git/vault` symlink 切り替えの度に livenessProbe で失敗 → kubelet による container restart(~30-90秒のダウンタイム)になっていた挙動を、コンテナ内スーパーバイザで in-place ホットスワップする形に変更する。

## 背景

現行構成では起動時に `readlink -f /git/vault` を `/tmp/vault-path` に固定し、以後 livenessProbe で symlink 実体が変わったら fail させて container 再起動を促していた。git-sync がコミットを取り込むたびに:

1. Kubelet が failureThreshold(既定 3)× periodSeconds(30s)= ~90秒 の失敗を待って kill
2. Container 再起動 + `npx` cold cache
3. Ready まで合計 ~30-90秒 のダウンタイム

一方 `@bitbonsai/mcpvault` は起動時に vault パスを解決してキャッシュするため、symlink 差し替えだけでは追随できず、直後の MCP 呼び出しは `ENOENT: /git/root/.worktrees/<old-sha>` を返す。

## 変更内容

`mcpvault` コンテナの `args` を書き換え、シェルスクリプトで `mcpvault` プロセスをバックグラウンド起動 + 10 秒周期で `readlink -f /git/vault` を監視 → 変化検知でプロセスを SIGTERM & 再起動する supervisor loop に。

- git-sync による worktree ローテーション時は、コンテナは生かしたまま子プロセスだけ再起動 → 数秒のダウンで済む
- `mcpvault` 子プロセス自体が死んだ場合はスーパーバイザが exit 1 して従来通り kubelet に再起動を任せる
- SIGTERM 受信時は `trap` で子プロセスに伝播 + `wait` で終了を待って exit
- livenessProbe は exec の symlink 比較を廃止し、readinessProbe と同じ tcpSocket 3001 チェックに簡素化(symlink 検知は supervisor が担うため)

## 動作確認

- 手元で本 branch を apply → git-sync が新コミットを取り込んだ際に mcpvault が container restart なしに新 worktree を掴み直せる
- MCP 呼び出しが最新の vault を返すことを確認