### PR TITLE
feat(k8s): expose kube-apiserver via cloudflared + cloudflare access

### DIFF
--- a/docs/kube-apiserver-access.md
+++ b/docs/kube-apiserver-access.md
@@ -1,0 +1,42 @@
+# kube-apiserver Public Access
+
+`k8s.toof.jp` exposes the in-cluster `kubernetes.default.svc` (kube-apiserver) as a TCP endpoint through a dedicated Cloudflare Tunnel. Cloudflare Zero Trust Access (GitHub SSO, `toof@toof.jp`) sits in front of the tunnel; the apiserver's own TLS + client certificate authentication is preserved end-to-end (Cloudflare does not terminate the apiserver TLS).
+
+## Components
+
+- `terraform/kube_apiserver.tf` — named tunnel `kube-apiserver`, its remote ingress config (`k8s.toof.jp` → `tcp://kubernetes.default.svc.cluster.local:443`), the CNAME `k8s.toof.jp` → `<tunnel-id>.cfargotunnel.com`, the Zero Trust Access application, and the Secret Manager entry `cloudflared-kube-apiserver-tunnel-token`.
+- `kubernetes/applications/cloudflared-kube-apiserver/` — cloudflared Deployment (2 replicas) and the ExternalSecret that syncs the token from Secret Manager.
+
+## Client setup
+
+1. Install `cloudflared` locally.
+2. Log in once so the browser SSO cookie is cached: `cloudflared access login https://k8s.toof.jp`.
+3. Start the local TCP proxy in a long-running terminal / systemd user unit:
+
+   ```
+   cloudflared access tcp --hostname k8s.toof.jp --url localhost:16443
+   ```
+
+4. Add a kubeconfig context that points at the local proxy. Client cert / CA data stays whatever `kubeadm` issued; only `server` and `tls-server-name` change:
+
+   ```yaml
+   clusters:
+     - name: toof-public
+       cluster:
+         server: https://localhost:16443
+         tls-server-name: kubernetes
+         certificate-authority-data: <same as the existing in-cluster context>
+   contexts:
+     - name: toof-public
+       context:
+         cluster: toof-public
+         user: <existing kubeadm client cert user>
+   ```
+
+   `tls-server-name: kubernetes` is required because `localhost` is not in the apiserver's cert SANs; `kubernetes` is (kubeadm always adds it).
+
+## Notes
+
+- The tunnel is fronted by Cloudflare Access, so `cloudflared access tcp` will prompt for the GitHub SSO flow the first time (or after the 24 h session expires).
+- Client-cert mTLS still runs between kubectl and the apiserver — Cloudflare only sees an opaque TCP stream. Revoking access requires updating the Cloudflare Access policy _and_ (for a compromised client cert) rotating the kubeadm CA / issuing a new client cert.
+- The cloudflared Deployment runs inside the cluster and dials `kubernetes.default.svc.cluster.local:443`, so if the apiserver is completely down the tunnel is also unreachable — this is not a recovery path for a broken cluster. Use direct Tailscale + `kubectl --server=https://100.83.127.53:6443` from zen2 for that.

--- a/kubernetes/applications/cloudflared-kube-apiserver/cloudflared.yaml
+++ b/kubernetes/applications/cloudflared-kube-apiserver/cloudflared.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflared-kube-apiserver-tunnel
+  namespace: cloudflared-kube-apiserver
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: cloudflared-kube-apiserver-tunnel
+  data:
+    - secretKey: token
+      remoteRef:
+        key: cloudflared-kube-apiserver-tunnel-token
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+  namespace: cloudflared-kube-apiserver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cloudflared
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: cloudflared
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:2024.12.2
+          args:
+            - tunnel
+            - --no-autoupdate
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared-kube-apiserver-tunnel
+                  key: token
+          ports:
+            - name: metrics
+              containerPort: 2000
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: cloudflared
+                topologyKey: kubernetes.io/hostname

--- a/kubernetes/applications/cloudflared-kube-apiserver/namespace.yaml
+++ b/kubernetes/applications/cloudflared-kube-apiserver/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudflared-kube-apiserver

--- a/terraform/kube_apiserver.tf
+++ b/terraform/kube_apiserver.tf
@@ -1,0 +1,74 @@
+resource "random_id" "kube_apiserver_tunnel_secret" {
+  byte_length = 32
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "kube_apiserver" {
+  account_id    = var.cloudflare_account_id
+  name          = "kube-apiserver"
+  config_src    = "cloudflare"
+  tunnel_secret = random_id.kube_apiserver_tunnel_secret.b64_std
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "kube_apiserver" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.kube_apiserver.id
+
+  config = {
+    ingress = [
+      {
+        hostname = "k8s.${var.domain}"
+        service  = "tcp://kubernetes.default.svc.cluster.local:443"
+      },
+      {
+        service = "http_status:404"
+      },
+    ]
+  }
+}
+
+data "cloudflare_zero_trust_tunnel_cloudflared_token" "kube_apiserver" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.kube_apiserver.id
+}
+
+resource "cloudflare_dns_record" "k8s" {
+  zone_id = cloudflare_zone.toof_jp.id
+  name    = "k8s.${var.domain}"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.kube_apiserver.id}.cfargotunnel.com"
+}
+
+resource "cloudflare_zero_trust_access_application" "kube_apiserver" {
+  account_id           = var.cloudflare_account_id
+  name                 = "kube-apiserver"
+  domain               = "k8s.${var.domain}"
+  type                 = "self_hosted"
+  session_duration     = "24h"
+  app_launcher_visible = false
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.github.id
+  ]
+
+  policies = [
+    {
+      id         = cloudflare_zero_trust_access_policy.allow_github_toof.id
+      precedence = 1
+    }
+  ]
+}
+
+resource "google_secret_manager_secret" "cloudflared_kube_apiserver_tunnel_token" {
+  secret_id = "cloudflared-kube-apiserver-tunnel-token"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "cloudflared_kube_apiserver_tunnel_token" {
+  secret      = google_secret_manager_secret.cloudflared_kube_apiserver_tunnel_token.id
+  secret_data = data.cloudflare_zero_trust_tunnel_cloudflared_token.kube_apiserver.token
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -48,6 +48,11 @@ terraform {
       source  = "hashicorp/tls"
       version = "~> 4"
     }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3"
+    }
   }
 
   cloud {


### PR DESCRIPTION
## Summary

- `k8s.toof.jp` を専用の Cloudflare Named Tunnel + Zero Trust Access (GitHub SSO, `toof@toof.jp`) の背後に公開し、外部から `kubectl` で apiserver にアクセスできるようにする
- Cloudflare は TCP を通すだけで apiserver の TLS を終端しないので、既存の kubeadm 発行クライアント証明書 (mTLS) 認証はそのまま維持される
- 追加コンポーネント:
  - Terraform: 専用 tunnel + remote ingress config (`tcp://kubernetes.default.svc.cluster.local:443`) + `k8s.toof.jp` CNAME + Access application (`app_launcher_visible=false`) + GCP Secret Manager `cloudflared-kube-apiserver-tunnel-token`
  - Kubernetes: `cloudflared-kube-apiserver` namespace、ExternalSecret、cloudflared Deployment (2 replicas, non-root, readOnlyRootFilesystem, podAntiAffinity)
  - `hashicorp/random` provider を追加 (`tunnel_secret` 生成用)
- `docs/kube-apiserver-access.md` にクライアント側 (`cloudflared access tcp` → local port → kubeconfig の `tls-server-name: kubernetes` で SNI 合わせ) の手順をまとめた

## 補足

- apiserver 側の cert SANs は変更しない方針にした (`nix-sandbox` 側の変更を避けるため)。`localhost` は SAN に入っていないので kubeconfig に `tls-server-name: kubernetes` を付ける必要がある
- cloudflared はクラスタ内から `kubernetes.default.svc.cluster.local:443` を叩く構成なので、apiserver 自体が落ちているときの復旧経路にはならない (その場合は従来通り zen2 の Tailscale 経由)
- 既存の `cloudflare-tunnel-ingress-controller` (HTTP 用) とは別 tunnel

## Test plan

- [ ] HCP Terraform plan で tunnel / DNS / Access app / Secret Manager が意図通りに作られること
- [ ] apply 後 `k8s.toof.jp` の CNAME が `<tunnel-id>.cfargotunnel.com` を指し、Cloudflare Access アプリが GitHub-only ポリシーで保護されていること
- [ ] Argo CD が `cloudflared-kube-apiserver` app を sync し、cloudflared Pod が Ready + tunnel が Cloudflare 側で Healthy になること
- [ ] ローカルで \`cloudflared access tcp --hostname k8s.toof.jp --url localhost:16443\` → 新 context の kubectl で `kubectl get nodes` が通ること (SSO 未認証時は browser flow が走ること)

🤖 Generated with [Claude Code](https://claude.com/claude-code)