### PR TITLE
chore(mirakc): scale mirakc to 0 replicas

### DIFF
--- a/kubernetes/applications/mirakc/mirakc.yaml
+++ b/kubernetes/applications/mirakc/mirakc.yaml
@@ -20,7 +20,7 @@ metadata:
   name: mirakc
   namespace: mirakc
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## 概要

- チューナー機材を物理的に移設するため、mirakc Deployment を一旦 `replicas: 0` にする
- EPGStation はそのまま残す（録画済ファイル・DB を保持）

## 復帰手順

移設先で受信確認できたら:

1. 必要に応じて `mirakc-config.yaml` の `channels:` を移設先の物理チャンネルに更新
2. 本 PR を revert または `replicas: 1` に戻す PR を作成

## Test plan

- [ ] Argo CD が mirakc Deployment を `replicas: 0` に同期する
- [ ] `kubectl -n mirakc get deploy mirakc` で `READY 0/0` を確認
- [ ] EPGStation Pod は引き続き Running のまま（mirakc への接続はエラーになる想定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)