### PR TITLE
chore(mirakc): scale epgstation to 0 replicas

### DIFF
--- a/kubernetes/applications/mirakc/epgstation.yaml
+++ b/kubernetes/applications/mirakc/epgstation.yaml
@@ -38,7 +38,7 @@ metadata:
   name: epgstation
   namespace: mirakc
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## 概要
- `epgstation` Deployment の `replicas` を `1` → `0` に変更し、Pod を停止する
- 先行して停止した mirakc (#279) と揃える

## テスト計画
- [ ] Argo CD で mirakc namespace の epgstation Deployment が 0/0 になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)