### PR TITLE
fix(cloudflared-kube-apiserver): force http2 transport

### DIFF
--- a/kubernetes/applications/cloudflared-kube-apiserver/cloudflared.yaml
+++ b/kubernetes/applications/cloudflared-kube-apiserver/cloudflared.yaml
@@ -48,6 +48,8 @@ spec:
           args:
             - tunnel
             - --no-autoupdate
+            - --protocol
+            - http2
             - --metrics
             - 0.0.0.0:2000
             - run


### PR DESCRIPTION
## 概要

`cloudflared-kube-apiserver` の全 Pod が liveness probe で 503 を返し続けて再起動ループに入っており、tunnel が確立できていなかったので `--protocol http2` を明示して修正する。

## 原因

Pod のログを確認すると以下の状態:

```
Initial protocol quic
Failed to dial a quic connection error="failed to dial to edge with quic: timeout: no recent network activity"
```

connectivity pre-check の結果:

```
UDP Connectivity  region1.v2.argotunnel.com  FAIL  QUIC connection failed
TCP Connectivity  region1.v2.argotunnel.com  PASS  HTTP/2 connection successful
SUMMARY: Environment ready with degraded transport. cloudflared will proceed using 'http2'.
```

- 現在の worker node からは QUIC (UDP:7844) の egress が通っていない (TCP は OK)
- precheck は http2 へフォールバックすると通知するが、実際の tunnel loop は `Initial protocol quic` のまま QUIC リトライを繰り返し、http2 に自動で切り替わっていない
- 結果 `/ready` が 503 を返し続け、Deployment (2 replicas) 両方が `Available=0`
- PR #274 でデプロイされて以降ずっと動いていない (nuc の Pod は 21h で 232 restart)

## 変更内容

`kubernetes/applications/cloudflared-kube-apiserver/cloudflared.yaml` の args に `--protocol http2` を追加。precheck の suggestion (http2) に合わせて transport を固定する。

`--protocol` フラグは cloudflared のヘルプでは Hidden 扱いだが、cloudflare/cloudflared master でも現役で `auto|quic|http2` を受け付ける (env var: `TUNNEL_TRANSPORT_PROTOCOL`)。

## 動作確認

- [ ] Argo CD が sync 後、Pod の `/ready` が 200 を返す
- [ ] `kubectl get deploy -n cloudflared-kube-apiserver` で `Available=2`
- [ ] `k8s.<domain>` 経由で kube-apiserver にアクセスできる