### PR TITLE
chore(openclaw): scale to 0 replicas

### DIFF
--- a/kubernetes/applications/openclaw/openclaw.yaml
+++ b/kubernetes/applications/openclaw/openclaw.yaml
@@ -19,7 +19,7 @@ metadata:
   name: openclaw
   namespace: openclaw
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## 概要
- openclaw Deployment を一時的に `replicas: 0` にスケールダウン

## Test plan
- [ ] Argo CD の sync 後、`openclaw` namespace で openclaw Pod が 0 になっていること