### PR TITLE
feat(openclaw): switch model provider to opencode Go DeepSeek and resume

### DIFF
--- a/kubernetes/applications/openclaw/README.md
+++ b/kubernetes/applications/openclaw/README.md
@@ -6,13 +6,13 @@
 - Discord: bot connection via `DISCORD_BOT_TOKEN`
 - Cluster access: read-only RBAC (`view` + cluster-scoped read) with `kubectl` installed by an init container
 - Prometheus: `http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090`
-- Model: Claude on Vertex AI (`anthropic-vertex/claude-sonnet-4-6`) via the `openclaw-vertex-sa` service account
+- Model: DeepSeek V4 Flash on [opencode Go](https://opencode.ai/docs/go/) (`opencode-go/deepseek-v4-flash`)
 
-## Vertex AI Provider
+## Model Provider
 
-The agent talks to Claude through Google Vertex AI instead of the Anthropic API. Terraform (`terraform/service_account.tf`, `terraform/api.tf`) provisions everything: enables `aiplatform.googleapis.com`, creates the `openclaw-vertex-sa` service account with `roles/aiplatform.user`, and stores its key in GCP Secret Manager as `openclaw-vertex-sa-key`. The Deployment mounts the key and sets `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION` for ADC.
+The agent talks to DeepSeek through the opencode Go subscription, declared in `openclaw.json` as the custom `opencode-go` provider: OpenAI-compatible API at `https://opencode.ai/zen/go/v1`, authenticated with the `OPENCODE_API_KEY` environment variable that comes from the `openclaw-secret` ExternalSecret.
 
-The official Docker image does not bundle the Vertex provider, but no manual install is needed: the plugins are declared in `openclaw.json` (`plugins.entries`), and the gateway's startup doctor auto-installs `@openclaw/anthropic-vertex-provider` and `@openclaw/discord` from npm onto the state PVC on first start.
+Only the Discord plugin is declared in `plugins.entries`; the gateway's startup doctor auto-installs `@openclaw/discord` from npm onto the state PVC on first start. A custom OpenAI-compatible provider needs no plugin.
 
 ## Secret Values
 
@@ -20,6 +20,7 @@ Create these secrets in GCP Secret Manager (project `toof-infra`):
 
 - `openclaw-discord-bot-token`: Discord bot token (see below)
 - `openclaw-gateway-token`: any random string used to authenticate to the Control UI
+- `openclaw-opencode-api-key`: opencode Zen/Go API key from <https://opencode.ai/auth>
 
 Read the current value of the gateway token (mirrored into the cluster as `openclaw-gateway-token-secret`) with:
 

--- a/kubernetes/applications/openclaw/configmap.yaml
+++ b/kubernetes/applications/openclaw/configmap.yaml
@@ -19,32 +19,29 @@ data:
         "entries": {
           "discord": {
             "enabled": true
-          },
-          "anthropic-vertex": {
-            "enabled": true
           }
         }
       },
       "models": {
         "providers": {
-          "anthropic-vertex": {
-            "baseUrl": "https://aiplatform.googleapis.com",
-            "api": "anthropic-messages",
-            "apiKey": "gcp-vertex-credentials",
+          "opencode-go": {
+            "baseUrl": "https://opencode.ai/zen/go/v1",
+            "api": "openai-completions",
+            "apiKey": "${OPENCODE_API_KEY}",
             "models": [
               {
-                "id": "claude-sonnet-4-6",
-                "name": "Claude Sonnet 4.6",
+                "id": "deepseek-v4-flash",
+                "name": "DeepSeek V4 Flash",
                 "reasoning": true,
-                "input": ["text", "image"],
+                "input": ["text"],
                 "cost": {
-                  "input": 3,
-                  "output": 15,
-                  "cacheRead": 0.3,
-                  "cacheWrite": 3.75
+                  "input": 0.14,
+                  "output": 0.28,
+                  "cacheRead": 0.0028,
+                  "cacheWrite": 0
                 },
                 "contextWindow": 1000000,
-                "maxTokens": 128000
+                "maxTokens": 384000
               }
             ]
           }
@@ -75,8 +72,7 @@ data:
       "agents": {
         "defaults": {
           "model": {
-            "primary": "anthropic-vertex/claude-sonnet-4-6",
-            "fallbacks": ["google-vertex/gemini-2.5-pro"]
+            "primary": "opencode-go/deepseek-v4-flash"
           }
         }
       },

--- a/kubernetes/applications/openclaw/external-secret.yaml
+++ b/kubernetes/applications/openclaw/external-secret.yaml
@@ -15,24 +15,9 @@ spec:
     - secretKey: DISCORD_BOT_TOKEN
       remoteRef:
         key: openclaw-discord-bot-token
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: openclaw-vertex-sa-key-external-secret
-  namespace: openclaw
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: gcp-secret-manager
-    kind: ClusterSecretStore
-  target:
-    name: openclaw-vertex-sa-key
-  data:
-    - secretKey: GOOGLE_CREDENTIALS_JSON
+    - secretKey: OPENCODE_API_KEY
       remoteRef:
-        key: openclaw-vertex-sa-key
-        decodingStrategy: Base64
+        key: openclaw-opencode-api-key
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/kubernetes/applications/openclaw/openclaw.yaml
+++ b/kubernetes/applications/openclaw/openclaw.yaml
@@ -19,7 +19,7 @@ metadata:
   name: openclaw
   namespace: openclaw
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -71,12 +71,6 @@ spec:
           env:
             - name: PATH
               value: /tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /var/secrets/google/key.json
-            - name: GOOGLE_CLOUD_PROJECT
-              value: toof-infra
-            - name: GOOGLE_CLOUD_LOCATION
-              value: global
           envFrom:
             - secretRef:
                 name: openclaw-secret
@@ -99,9 +93,6 @@ spec:
             - name: state
               mountPath: /home/node/.config/openclaw
               subPath: config
-            - name: vertex-sa-key
-              mountPath: /var/secrets/google
-              readOnly: true
             - name: tools
               mountPath: /tools
       volumes:
@@ -111,12 +102,6 @@ spec:
         - name: config
           configMap:
             name: openclaw-config
-        - name: vertex-sa-key
-          secret:
-            secretName: openclaw-vertex-sa-key
-            items:
-              - key: GOOGLE_CREDENTIALS_JSON
-                path: key.json
         - name: tools
           emptyDir: {}
 ---

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -14,7 +14,6 @@ locals {
     "run.googleapis.com",
     "eventarc.googleapis.com",
     "secretmanager.googleapis.com",
-    "aiplatform.googleapis.com",
   ]
 }
 

--- a/terraform/service_account.tf
+++ b/terraform/service_account.tf
@@ -60,32 +60,3 @@ resource "google_secret_manager_secret_version" "otel_sa_secret_ver" {
   secret      = google_secret_manager_secret.otel_sa_secret.id
   secret_data = google_service_account_key.otel_sa_key.private_key
 }
-
-resource "google_service_account" "openclaw_vertex_sa" {
-  account_id   = "openclaw-vertex-sa"
-  display_name = "Service account for OpenClaw Vertex AI"
-  depends_on   = [google_project_service.enabled["iam.googleapis.com"]]
-}
-
-resource "google_project_iam_member" "openclaw_vertex_sa" {
-  project = google_project.toof_infra.project_id
-  role    = "roles/aiplatform.user"
-  member  = "serviceAccount:${google_service_account.openclaw_vertex_sa.email}"
-}
-
-resource "google_service_account_key" "openclaw_vertex_sa_key" {
-  service_account_id = google_service_account.openclaw_vertex_sa.name
-}
-
-resource "google_secret_manager_secret" "openclaw_vertex_sa_secret" {
-  secret_id = "openclaw-vertex-sa-key"
-  replication {
-    auto {}
-  }
-  depends_on = [google_project_service.enabled["secretmanager.googleapis.com"]]
-}
-
-resource "google_secret_manager_secret_version" "openclaw_vertex_sa_secret_ver" {
-  secret      = google_secret_manager_secret.openclaw_vertex_sa_secret.id
-  secret_data = google_service_account_key.openclaw_vertex_sa_key.private_key
-}


### PR DESCRIPTION
## 概要

OpenClaw の運用を再開する。モデルプロバイダを Vertex AI (Claude / Gemini) から [opencode Go](https://opencode.ai/docs/go/) の OpenAI 互換 API に切り替え、DeepSeek V4 Flash を使う。

## 変更内容

- `replicas: 0` → `1` で運用再開
- `openclaw.json`
  - プロバイダ `opencode-go` を追加（`https://opencode.ai/zen/go/v1`、`openai-completions`、`apiKey: ${OPENCODE_API_KEY}`）
  - モデルは `opencode-go/deepseek-v4-flash`（context 1M / output 384k、$0.14 / $0.28 per 1M tokens）
  - `anthropic-vertex` のプラグイン・プロバイダ定義と `google-vertex/gemini-2.5-pro` フォールバックを削除。OpenAI 互換プロバイダはプラグイン不要
- ExternalSecret
  - `openclaw-secret` に `OPENCODE_API_KEY`（GCP Secret Manager の `openclaw-opencode-api-key`）を追加
  - `openclaw-vertex-sa-key` の ExternalSecret を削除
- Deployment から Vertex 用の SA キーの volume/mount と `GOOGLE_APPLICATION_CREDENTIALS` / `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` を削除
- Terraform から `openclaw-vertex-sa`（SA・キー・`roles/aiplatform.user`・Secret Manager シークレット）と `aiplatform.googleapis.com` の有効化を削除

## マージ前に必要な作業

GCP Secret Manager (`toof-infra`) に opencode の API キーを登録する。未登録のまま merge すると ExternalSecret の同期が失敗し、`${OPENCODE_API_KEY}` が解決できずモデル呼び出しが認証エラーになる。

```sh
printf '%s' '<opencode API key>' | \
  gcloud secrets create openclaw-opencode-api-key --project toof-infra --data-file=-
```

API キーは <https://opencode.ai/auth> で opencode Go を契約すると取得できる。

## 補足

- フォールバックモデルは無し（Vertex を完全に削除したため）。DeepSeek 側が落ちた場合はエージェントがエラーになる
- Terraform 側は `aiplatform.googleapis.com` が無効化される。今後 Vertex を使う場合は再度有効化が必要