### PR TITLE
fix(openclaw): use mimo-v2.5 instead of the opt-in gated deepseek

### DIFF
--- a/kubernetes/applications/openclaw/README.md
+++ b/kubernetes/applications/openclaw/README.md
@@ -6,11 +6,13 @@
 - Discord: bot connection via `DISCORD_BOT_TOKEN`
 - Cluster access: read-only RBAC (`view` + cluster-scoped read) with `kubectl` installed by an init container
 - Prometheus: `http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090`
-- Model: DeepSeek V4 Flash on [opencode Go](https://opencode.ai/docs/go/) (`opencode-go/deepseek-v4-flash`)
+- Model: MiMo V2.5 on [opencode Go](https://opencode.ai/docs/go/) (`opencode-go/mimo-v2.5`)
 
 ## Model Provider
 
-The agent talks to DeepSeek through the opencode Go subscription, declared in `openclaw.json` as the custom `opencode-go` provider: OpenAI-compatible API at `https://opencode.ai/zen/go/v1`, authenticated with the `OPENCODE_API_KEY` environment variable that comes from the `openclaw-secret` ExternalSecret.
+The agent talks to the model through the opencode Go subscription, declared in `openclaw.json` as the custom `opencode-go` provider: OpenAI-compatible API at `https://opencode.ai/zen/go/v1`, authenticated with the `OPENCODE_API_KEY` environment variable that comes from the `openclaw-secret` ExternalSecret.
+
+DeepSeek V4 Flash was the first choice but opencode Go rejects it with `403 The latest version of this model is only available hosted in China and requires explicit opt in`, so it needs an opt-in in the opencode workspace before it can be used.
 
 Only the Discord plugin is declared in `plugins.entries`; the gateway's startup doctor auto-installs `@openclaw/discord` from npm onto the state PVC on first start. A custom OpenAI-compatible provider needs no plugin.
 

--- a/kubernetes/applications/openclaw/configmap.yaml
+++ b/kubernetes/applications/openclaw/configmap.yaml
@@ -30,10 +30,10 @@ data:
             "apiKey": "${OPENCODE_API_KEY}",
             "models": [
               {
-                "id": "deepseek-v4-flash",
-                "name": "DeepSeek V4 Flash",
+                "id": "mimo-v2.5",
+                "name": "MiMo V2.5",
                 "reasoning": true,
-                "input": ["text"],
+                "input": ["text", "image"],
                 "cost": {
                   "input": 0.14,
                   "output": 0.28,
@@ -41,7 +41,7 @@ data:
                   "cacheWrite": 0
                 },
                 "contextWindow": 1000000,
-                "maxTokens": 384000
+                "maxTokens": 128000
               }
             ]
           }
@@ -72,7 +72,7 @@ data:
       "agents": {
         "defaults": {
           "model": {
-            "primary": "opencode-go/deepseek-v4-flash"
+            "primary": "opencode-go/mimo-v2.5"
           }
         }
       },


### PR DESCRIPTION
## 背景

#294 で設定した `opencode-go/deepseek-v4-flash` が実際には呼び出せず、cron の `cluster-health` が失敗し続けている。

```
403 The latest version of this model is only available hosted in China and
requires explicit opt in: https://opencode.ai/workspace/wrk_.../go
```

API キーの認証自体は通っており（401 ではなく 403）、モデル固有の opt-in 制限。opencode の workspace で明示的に opt in しない限り使えない。

## 変更内容

プライマリモデルを `opencode-go/mimo-v2.5` に変更する。

- 価格は deepseek-v4-flash と同じ $0.14 / $0.28 per 1M tokens
- context 1M / output 128k、reasoning・tool call 対応
- opt-in 不要

## 検証

Pod 内から同じプロバイダ設定で実行し、モデル呼び出しとツール利用を確認した。

```
$ openclaw agent --model opencode-go/mimo-v2.5 \
    -m 'Use kubectl to count the Kubernetes nodes in this cluster ...'
4 nodes: nuc, sakura-vps, vultr-vps, zen2.
```

他の候補も同様に実機で確認した結果:

| モデル | 価格 (in/out) | 結果 |
| --- | --- | --- |
| `mimo-v2.5` | $0.14 / $0.28 | OK |
| `gpt-5.6-luna` | $0.10 / $0.60 | OK |
| `minimax-m3` | $0.30 / $1.20 | OK |
| `qwen3.7-plus` | $0.40 / $1.60 | OK |
| `deepseek-v4-pro` | $0.435 / $0.87 | OK |
| `deepseek-v4-flash` | $0.14 / $0.28 | 403（opt-in 必須） |
| `hy3` | $0.14 / $0.58 | context 不足（256k） |
| `grok-4.5` | $2 / $6 | 500（プロバイダ側エラー、3 回とも） |

## マージ後の作業

ConfigMap は init コンテナが Pod 起動時に state PVC へコピーする構成のため、反映には再起動が必要。

```sh
kubectl -n openclaw rollout restart deploy/openclaw
```

## 既知の問題（本 PR では対応しない）

Pod が liveness probe 失敗で再起動している（`Liveness probe failed: ... context deadline exceeded`）。起動に約 50 秒かかることと、エージェント実行中のイベントループ飽和が原因で、コンテナに resource requests が無いことも影響している。